### PR TITLE
Implemented auto mapping, default schemas attributes and default hydrators attributes

### DIFF
--- a/config/json-api.php
+++ b/config/json-api.php
@@ -42,6 +42,7 @@ return [
     */
     'namespaces' => [
         'v1' => [
+            'automapping' => false,
             'url-prefix' => '/api/v1',
             'supported-ext' => null,
             'paging' => [

--- a/src/Hydrator/EloquentHydrator.php
+++ b/src/Hydrator/EloquentHydrator.php
@@ -117,6 +117,32 @@ class EloquentHydrator extends AbstractHydrator implements HydratesRelatedInterf
     }
 
     /**
+     * @param StandardObjectInterface $attributes
+     * @param $record
+     * @return void
+     */
+    protected function defaultHydrateAttributes(StandardObjectInterface $attributes, $record)
+    {
+        $hydratorAttributes = $this->attributes;
+        if(empty($hydratorAttributes))
+        {
+            $hydratorAttributes = [];
+            foreach($record->getFillable() as $attribute)
+            {
+                if(strpos($attribute, '_') !== false)
+                {
+                    $hydratorAttributes[str_replace('_', '-', $attribute)] = $attribute;
+                }
+                else
+                {
+                    $hydratorAttributes[] = $attribute;
+                }
+            }
+        }
+        return $hydratorAttributes;
+    }
+
+    /**
      * @inheritDoc
      */
     protected function hydrateAttributes(StandardObjectInterface $attributes, $record)
@@ -127,7 +153,7 @@ class EloquentHydrator extends AbstractHydrator implements HydratesRelatedInterf
 
         $data = [];
 
-        foreach ($this->attributes as $resourceKey => $modelKey) {
+        foreach ($this->defaultHydrateAttributes($attributes, $record) as $resourceKey => $modelKey) {
             if (is_numeric($resourceKey)) {
                 $resourceKey = $modelKey;
                 $modelKey = $this->keyForAttribute($modelKey, $record);

--- a/src/Repositories/EloquentSchemasRepository.php
+++ b/src/Repositories/EloquentSchemasRepository.php
@@ -7,7 +7,7 @@ use CloudCreativity\JsonApi\Contracts\Repositories\SchemasRepositoryInterface;
 use ReflectionClass;
 use Config;
 
-class SchemasRepository implements SchemasRepositoryInterface
+class EloquentSchemasRepository implements SchemasRepositoryInterface
 {
     const JSON_API_SCHEMA = 'JSON_API_SCHEMA';
 

--- a/src/Repositories/SchemasRepository.php
+++ b/src/Repositories/SchemasRepository.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace CloudCreativity\LaravelJsonApi\Repositories;
+
+use Neomerx\JsonApi\Contracts\Schema\SchemaFactoryInterface;
+use CloudCreativity\JsonApi\Contracts\Repositories\SchemasRepositoryInterface;
+use ReflectionClass;
+use Config;
+
+class SchemasRepository implements SchemasRepositoryInterface
+{
+    const JSON_API_SCHEMA = 'JSON_API_SCHEMA';
+
+    private $factory;
+
+    private $namespaced = false;
+
+    private $schemas = [];
+
+    public function __construct(SchemaFactoryInterface $factory = null)
+    {
+        $this->factory = $factory ?: new Factory();
+    }
+
+    public function getSchemas($name = null)
+    {
+        $name = ($name) ?: static::DEFAULTS;
+
+        if (static::DEFAULTS !== $name && !$this->namespaced) {
+            throw new \RuntimeException(sprintf('Schemas configuration is not namespaced, so cannot get "%s".', $name));
+        }
+
+        $defaults = $this->get(static::DEFAULTS);
+        $schemas = (static::DEFAULTS === $name) ? $defaults : array_merge($defaults, $this->get($name));
+
+        return $this->factory->createContainer($schemas);
+    }
+
+    public function configure(array $config)
+    {
+        if (!isset($config[static::DEFAULTS])) {
+            $config = [static::DEFAULTS => $config];
+            $this->namespaced = false;
+        } else {
+            $this->namespaced = true;
+        }
+
+        $this->schemas = $config;
+        
+        $automappingNamespaces = [];
+        foreach(Config::get('json-api.namespaces') as $key => $value)
+        {
+            if(isset($value['automapping']) && $value['automapping'])
+            {
+                $automappingNamespaces[] = $key;
+            }
+        }
+
+        if(! empty($automappingNamespaces))
+        {
+            $models = array_filter(glob('app/Models/*'), 'is_file');
+            foreach($models as $model)
+            {
+                $class = '';
+                foreach(explode('/', str_replace('.php', '', $model)) as $item) $class .= ucfirst($item).'\\';
+                $class = substr($class, 0, strlen($class) - 1);
+
+                if(class_exists($class))
+                {
+                    $jsonSchema = (new ReflectionClass($class))->getConstant(static::JSON_API_SCHEMA);
+                    if($jsonSchema)
+                    {
+                        foreach($this->schemas as $namespace => &$mappings)
+                        {
+                            if(in_array($namespace, $automappingNamespaces) && ! isset($mappings[$class]))
+                            {
+                                $mappings[$class] = $jsonSchema;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        return $this;
+    }
+
+    private function get($key)
+    {
+        return array_key_exists($key, $this->schemas) ? (array) $this->schemas[$key] : [];
+    }
+}

--- a/src/Schema/EloquentSchema.php
+++ b/src/Schema/EloquentSchema.php
@@ -155,6 +155,22 @@ abstract class EloquentSchema extends AbstractSchema
     }
 
     /**
+     * Get attributes for the provided model using fillable attribute.
+     *
+     * @param Model $model
+     * @return array
+     */
+    protected function getDefaultModelAttributes(Model $model)
+    {
+        $schemaAttributes = $this->attributes;
+        if(empty($schemaAttributes))
+        {
+            $schemaAttributes = $model->getFillable();
+        }
+        return $schemaAttributes;
+    }
+
+    /**
      * Get attributes for the provided model.
      *
      * @param Model $model
@@ -164,7 +180,7 @@ abstract class EloquentSchema extends AbstractSchema
     {
         $attributes = [];
 
-        foreach ($this->attributes as $modelKey => $attributeKey) {
+        foreach ($this->getDefaultModelAttributes($model) as $modelKey => $attributeKey) {
             if (is_numeric($modelKey)) {
                 $modelKey = $attributeKey;
                 $attributeKey = $this->keyForAttribute($attributeKey);

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -58,7 +58,7 @@ use CloudCreativity\LaravelJsonApi\Http\Middleware\HandleRequest;
 use CloudCreativity\LaravelJsonApi\Http\Requests\RequestInterpreter;
 use CloudCreativity\LaravelJsonApi\Http\Responses\Responses;
 use CloudCreativity\LaravelJsonApi\Pagination\Page;
-use CloudCreativity\LaravelJsonApi\Repositories\SchemasRepository;
+use CloudCreativity\LaravelJsonApi\Repositories\EloquentSchemasRepository;
 use CloudCreativity\LaravelJsonApi\Services\JsonApiService;
 use CloudCreativity\LaravelJsonApi\Validators\ValidatorErrorFactory;
 use CloudCreativity\LaravelJsonApi\Validators\ValidatorFactory;
@@ -260,7 +260,7 @@ class ServiceProvider extends BaseServiceProvider
      */
     protected function bindSchemasRepository()
     {
-        $this->app->singleton(SchemasRepositoryInterface::class, SchemasRepository::class);
+        $this->app->singleton(SchemasRepositoryInterface::class, EloquentSchemasRepository::class);
         $this->app->resolving(SchemasRepositoryInterface::class, function (ConfigurableInterface $repository) {
             $repository->configure((array) $this->getConfig('schemas', []));
         });
@@ -271,7 +271,7 @@ class ServiceProvider extends BaseServiceProvider
      */
     protected function bindSchemaRepository()
     {
-        $this->app->singleton(SchemasRepositoryInterface::class, SchemasRepository::class);
+        $this->app->singleton(SchemasRepositoryInterface::class, EloquentSchemasRepository::class);
         $this->app->resolving(SchemasRepositoryInterface::class, function (ConfigurableInterface $repository) {
             $repository->configure((array) $this->getConfig('schemas', []));
         });

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -39,7 +39,6 @@ use CloudCreativity\JsonApi\Http\Responses\ResponseFactory;
 use CloudCreativity\JsonApi\Pagination\Paginator;
 use CloudCreativity\JsonApi\Repositories\CodecMatcherRepository;
 use CloudCreativity\JsonApi\Repositories\ErrorRepository;
-use CloudCreativity\JsonApi\Repositories\SchemasRepository;
 use CloudCreativity\JsonApi\Store\Store;
 use CloudCreativity\JsonApi\Utils\Replacer;
 use CloudCreativity\LaravelJsonApi\Adapters\EloquentAdapter;
@@ -59,6 +58,7 @@ use CloudCreativity\LaravelJsonApi\Http\Middleware\HandleRequest;
 use CloudCreativity\LaravelJsonApi\Http\Requests\RequestInterpreter;
 use CloudCreativity\LaravelJsonApi\Http\Responses\Responses;
 use CloudCreativity\LaravelJsonApi\Pagination\Page;
+use CloudCreativity\LaravelJsonApi\Repositories\SchemasRepository;
 use CloudCreativity\LaravelJsonApi\Services\JsonApiService;
 use CloudCreativity\LaravelJsonApi\Validators\ValidatorErrorFactory;
 use CloudCreativity\LaravelJsonApi\Validators\ValidatorFactory;
@@ -75,6 +75,8 @@ use Neomerx\JsonApi\Contracts\Http\HttpFactoryInterface;
 use Neomerx\JsonApi\Contracts\Http\ResponsesInterface;
 use Neomerx\JsonApi\Contracts\Schema\SchemaFactoryInterface;
 use Psr\Log\LoggerInterface;
+use ReflectionClass;
+use App;
 
 /**
  * Class ServiceProvider
@@ -83,6 +85,7 @@ use Psr\Log\LoggerInterface;
  */
 class ServiceProvider extends BaseServiceProvider
 {
+    const JSON_API_SCHEMA = 'JSON_API_SCHEMA';
 
     /**
      * @var bool
@@ -352,6 +355,28 @@ class ServiceProvider extends BaseServiceProvider
         $this->app->singleton(EloquentAdapter::class, function () {
             $map = (array) $this->getConfig('eloquent-adapter.map');
             $columns = (array) $this->getConfig('eloquent-adapter.columns');
+
+            $models = array_filter(glob('app/Models/*'), 'is_file');
+            foreach($models as $model)
+            {
+                $class = '';
+                foreach(explode('/', str_replace('.php', '', $model)) as $item) $class .= ucfirst($item).'\\';
+                $class = substr($class, 0, strlen($class) - 1);
+
+                if(class_exists($class))
+                {
+                    $jsonSchema = (new ReflectionClass($class))->getConstant(static::JSON_API_SCHEMA);
+                    if($jsonSchema)
+                    {
+                        $resourceType = (new $jsonSchema(App::make(SchemaFactoryInterface::class)))
+                            ->getResourceType();
+                        if(! isset($map[$resourceType]))
+                        {
+                            $map[$resourceType] = $class;
+                        }
+                    }
+                }
+            }
 
             return new EloquentAdapter($map, $columns);
         });


### PR DESCRIPTION
The modern frameworks do implement automatic features in order to avoid complex configuration files that are modified, usually, by several developers.

In order to improve this package, we develop two features. First avoid modification of json-api.php configuration file to include mappings of schemas and adapters: these are included automatically (we call this **automapping**). The second feature uses fillable attributes from eloquent models to avoid repetition of these attributes declaration in the schema and hydrator classes (by default, if attributes are declared in schema/hydrator class, these are used).

To use automapping you have to follow these steps:

1. We have included a new configuration parameter in namespaces. Now, you can use automapping for several namespaces including `automapping: true` in their configuration. Example:

```
'namespaces' => [
    'v4' => [
        'automapping' => true,
        'url-prefix' => '/api/v4',
        'supported-ext' => null,
    ],
],
```

2. The mapping model/schema is declared in each Laravel model. Laravel models should be in `app/Models` folder. Also, in the model you have to declare a constant: `const JSON_API_SCHEMA = Schema::class;`.

3. The new implementation search in `app/Models` folder, classes that declare `JSON_API_SCHEMA` constant and generates automatic schema mappings for namespaces configured for this purpose, and also generates `eloquent-adapter` map using `resourceType` in schema classes.

4. Automapping don't overwrite declarations of mappings and adapters declared in `json-api.php` configuration file.

Note: We have created a completely new class called `CloudCreativity\LaravelJsonApi\Repositories\EloquentSchemasRepository` because `CloudCreativity\JsonApi\Repositories\SchemasRepository` have their attributes declared as private, and we can't inherit them.