### PR TITLE
Get default attributes for schemas and hydrators from model fillable attribute

### DIFF
--- a/src/Adapters/EloquentAdapter.php
+++ b/src/Adapters/EloquentAdapter.php
@@ -161,4 +161,20 @@ class EloquentAdapter implements AdapterInterface
             sprintf('%s.%s', $model->getTable(), $this->keyNames[$resourceType]) :
             $model->getQualifiedKeyName();
     }
+
+    /**
+     * Add a resource type and key name to Eloquent adapter
+     *
+     * @param string $resourceType
+     * @param string $model
+     * @param string $keyName
+     */
+    public function addResource($resourceType, $model, $keyName = NULL)
+    {
+        $this->map[$resourceType] = $model;
+        if(! is_null($keyName))
+        {
+            $this->keyNames[$resourceType] = $keyName;
+        }
+    }
 }

--- a/src/Hydrator/EloquentHydrator.php
+++ b/src/Hydrator/EloquentHydrator.php
@@ -115,6 +115,32 @@ class EloquentHydrator extends AbstractHydrator implements HydratesRelatedInterf
     {
         $this->service = $service;
     }
+    
+    /**
+     * @param StandardObjectInterface $attributes
+     * @param $record
+     * @return void
+     */
+    protected function defaultHydrateAttributes(StandardObjectInterface $attributes, $record)
+    {
+        $hydratorAttributes = $this->attributes;
+        if(empty($hydratorAttributes))
+        {
+            $hydratorAttributes = [];
+            foreach($record->getFillable() as $attribute)
+            {
+                if(strpos($attribute, '_') !== false)
+                {
+                    $hydratorAttributes[str_replace('_', '-', $attribute)] = $attribute;
+                }
+                else
+                {
+                    $hydratorAttributes[] = $attribute;
+                }
+            }
+        }
+        return $hydratorAttributes;
+    }
 
     /**
      * @inheritDoc
@@ -127,7 +153,7 @@ class EloquentHydrator extends AbstractHydrator implements HydratesRelatedInterf
 
         $data = [];
 
-        foreach ($this->attributes as $resourceKey => $modelKey) {
+        foreach ($this->defaultHydrateAttributes($attributes, $record) as $resourceKey => $modelKey) {
             if (is_numeric($resourceKey)) {
                 $resourceKey = $modelKey;
                 $modelKey = $this->keyForAttribute($modelKey, $record);

--- a/src/Schema/EloquentSchema.php
+++ b/src/Schema/EloquentSchema.php
@@ -155,6 +155,23 @@ abstract class EloquentSchema extends AbstractSchema
     }
 
     /**
+     * Get attributes for the provided model using fillable attribute.
+     *
+     * @param Model $model
+     * @return array
+     */
+    protected function getDefaultModelAttributes(Model $model)
+    {
+        $schemaAttributes = $this->attributes;
+        if(empty($schemaAttributes))
+        {
+            $schemaAttributes = $model->getFillable();
+        }
+        return $schemaAttributes;
+    }
+
+
+    /**
      * Get attributes for the provided model.
      *
      * @param Model $model
@@ -164,7 +181,7 @@ abstract class EloquentSchema extends AbstractSchema
     {
         $attributes = [];
 
-        foreach ($this->attributes as $modelKey => $attributeKey) {
+        foreach ($this->getDefaultModelAttributes($model) as $modelKey => $attributeKey) {
             if (is_numeric($modelKey)) {
                 $modelKey = $attributeKey;
                 $attributeKey = $this->keyForAttribute($attributeKey);

--- a/src/Services/JsonApiService.php
+++ b/src/Services/JsonApiService.php
@@ -22,8 +22,10 @@ use CloudCreativity\JsonApi\Contracts\Http\ApiInterface;
 use CloudCreativity\JsonApi\Contracts\Http\HttpServiceInterface;
 use CloudCreativity\JsonApi\Contracts\Http\Requests\RequestInterface;
 use CloudCreativity\JsonApi\Contracts\Http\Responses\ErrorResponseInterface;
+use CloudCreativity\JsonApi\Contracts\Store\StoreInterface;
 use CloudCreativity\JsonApi\Contracts\Utils\ErrorReporterInterface;
 use CloudCreativity\JsonApi\Exceptions\RuntimeException;
+use CloudCreativity\LaravelJsonApi\Adapters\EloquentAdapter;
 use CloudCreativity\LaravelJsonApi\Routing\ResourceRegistrar;
 use Exception;
 use Illuminate\Contracts\Container\Container;
@@ -59,6 +61,57 @@ class JsonApiService implements HttpServiceInterface, ErrorReporterInterface
      */
     public function resource($resourceType, $controller = null, array $options = [])
     {
+        /** @var ResourceRegistrar $registrar */
+        $registrar = $this->container->make(ResourceRegistrar::class);
+        $registrar->resource($resourceType, $controller, $options);
+
+        return $registrar;
+    }
+
+    /**
+     * Register a resource type with the router and register adapter.
+     *
+     * @param string $resourceType
+     * @param string $adapter
+     * @param string|null $controller
+     * @param array $options
+     * @return ResourceRegistrar
+     */
+    public function adapter($resourceType, $adapter, $controller = null, array $options = [])
+    {
+        $adapterObject = $this->container->make($adapter);
+        // Check if adapter recognises resource type
+        if(! $adapterObject->recognises($resourceType)) {
+            throw new RuntimeException("No adapter for resource type: $resourceType");
+        }
+
+        // Register adapter
+        $store = $this->container->make(StoreInterface::class);
+        $store->register($adapterObject);
+
+        /** @var ResourceRegistrar $registrar */
+        $registrar = $this->container->make(ResourceRegistrar::class);
+        $registrar->resource($resourceType, $controller, $options);
+
+        return $registrar;
+    }
+
+    /**
+     * Register a resource type with the router and include to the Eloquent adapter.
+     *
+     * @param string $resourceType
+     * @param string $model
+     * @param string $keyName
+     * @param string|null $controller
+     * @param array $options
+     * @return ResourceRegistrar
+     */
+    public function eloquentAdapter($resourceType, $model, $keyName = NULL, $controller = null, array $options = [])
+    {
+        // Include resource type to Eloquent adapter
+        $adapter = $this->container->make(EloquentAdapter::class);
+        $adapter->addResource($resourceType, $model, $keyName);
+
         /** @var ResourceRegistrar $registrar */
         $registrar = $this->container->make(ResourceRegistrar::class);
         $registrar->resource($resourceType, $controller, $options);


### PR DESCRIPTION
This implementation uses fillable attributes from eloquent models to avoid repetition of these attributes declaration in the schema and hydrator classes (by default, if attributes are declared in schema/hydrator class, these are used).