### PR TITLE
Use JsonApi in routes to register adapters

### DIFF
--- a/src/Adapters/EloquentAdapter.php
+++ b/src/Adapters/EloquentAdapter.php
@@ -169,10 +169,11 @@ class EloquentAdapter implements AdapterInterface
      * @param string $model
      * @param string $keyName
      */
-    public function addResource($resourceType, $model, $keyName = NULL)
+    public function addResource($resourceType, $model, $keyName = null)
     {
         $this->map[$resourceType] = $model;
-        if(! is_null($keyName))
+
+        if (! is_null($keyName))
         {
             $this->keyNames[$resourceType] = $keyName;
         }

--- a/src/Adapters/EloquentAdapter.php
+++ b/src/Adapters/EloquentAdapter.php
@@ -161,4 +161,20 @@ class EloquentAdapter implements AdapterInterface
             sprintf('%s.%s', $model->getTable(), $this->keyNames[$resourceType]) :
             $model->getQualifiedKeyName();
     }
+
+    /**
+     * Add a resource type and key name to Eloquent adapter
+     *
+     * @param string $resourceType
+     * @param string $model
+     * @param string $keyName
+     */
+    public function addResource($resourceType, $model, $keyName = NULL)
+    {
+        $this->map[$resourceType] = $model;
+        if(! is_null($keyName))
+        {
+            $this->keyNames[$resourceType] = $keyName;
+        }
+    }
 }

--- a/src/Services/JsonApiService.php
+++ b/src/Services/JsonApiService.php
@@ -80,6 +80,7 @@ class JsonApiService implements HttpServiceInterface, ErrorReporterInterface
     public function adapter($resourceType, $adapter, $controller = null, array $options = [])
     {
         $adapterObject = $this->container->make($adapter);
+        
         // Check if adapter recognises resource type
         if(! $adapterObject->recognises($resourceType)) {
             throw new RuntimeException("No adapter for resource type: $resourceType");
@@ -89,11 +90,7 @@ class JsonApiService implements HttpServiceInterface, ErrorReporterInterface
         $store = $this->container->make(StoreInterface::class);
         $store->register($adapterObject);
 
-        /** @var ResourceRegistrar $registrar */
-        $registrar = $this->container->make(ResourceRegistrar::class);
-        $registrar->resource($resourceType, $controller, $options);
-
-        return $registrar;
+        return $this->resource($resourceType, $controller, $options);
     }
 
     /**
@@ -112,11 +109,7 @@ class JsonApiService implements HttpServiceInterface, ErrorReporterInterface
         $adapter = $this->container->make(EloquentAdapter::class);
         $adapter->addResource($resourceType, $model, $keyName);
 
-        /** @var ResourceRegistrar $registrar */
-        $registrar = $this->container->make(ResourceRegistrar::class);
-        $registrar->resource($resourceType, $controller, $options);
-
-        return $registrar;
+        return $this->resource($resourceType, $controller, $options);
     }
 
     /**

--- a/src/Services/JsonApiService.php
+++ b/src/Services/JsonApiService.php
@@ -82,7 +82,7 @@ class JsonApiService implements HttpServiceInterface, ErrorReporterInterface
         $adapterObject = $this->container->make($adapter);
         
         // Check if adapter recognises resource type
-        if(! $adapterObject->recognises($resourceType)) {
+        if (! $adapterObject->recognises($resourceType)) {
             throw new RuntimeException("No adapter for resource type: $resourceType");
         }
 
@@ -103,7 +103,7 @@ class JsonApiService implements HttpServiceInterface, ErrorReporterInterface
      * @param array $options
      * @return ResourceRegistrar
      */
-    public function eloquentAdapter($resourceType, $model, $keyName = NULL, $controller = null, array $options = [])
+    public function eloquentAdapter($resourceType, $model, $keyName = null, $controller = null, array $options = [])
     {
         // Include resource type to Eloquent adapter
         $adapter = $this->container->make(EloquentAdapter::class);

--- a/src/Services/JsonApiService.php
+++ b/src/Services/JsonApiService.php
@@ -22,8 +22,10 @@ use CloudCreativity\JsonApi\Contracts\Http\ApiInterface;
 use CloudCreativity\JsonApi\Contracts\Http\HttpServiceInterface;
 use CloudCreativity\JsonApi\Contracts\Http\Requests\RequestInterface;
 use CloudCreativity\JsonApi\Contracts\Http\Responses\ErrorResponseInterface;
+use CloudCreativity\JsonApi\Contracts\Store\StoreInterface;
 use CloudCreativity\JsonApi\Contracts\Utils\ErrorReporterInterface;
 use CloudCreativity\JsonApi\Exceptions\RuntimeException;
+use CloudCreativity\LaravelJsonApi\Adapters\EloquentAdapter;
 use CloudCreativity\LaravelJsonApi\Routing\ResourceRegistrar;
 use Exception;
 use Illuminate\Contracts\Container\Container;
@@ -59,6 +61,57 @@ class JsonApiService implements HttpServiceInterface, ErrorReporterInterface
      */
     public function resource($resourceType, $controller = null, array $options = [])
     {
+        /** @var ResourceRegistrar $registrar */
+        $registrar = $this->container->make(ResourceRegistrar::class);
+        $registrar->resource($resourceType, $controller, $options);
+
+        return $registrar;
+    }
+
+    /**
+     * Register a resource type with the router and register adapter.
+     *
+     * @param string $resourceType
+     * @param string $adapter
+     * @param string|null $controller
+     * @param array $options
+     * @return ResourceRegistrar
+     */
+    public function adapter($resourceType, $adapter, $controller = null, array $options = [])
+    {
+        $adapterObject = $this->container->make($adapter);
+        // Check if adapter recognises resource type
+        if(! $adapterObject->recognises($resourceType)) {
+            throw new RuntimeException("No adapter for resource type: $resourceType");
+        }
+
+        // Register adapter
+        $store = $this->container->make(StoreInterface::class);
+        $store->register($adapterObject);
+
+        /** @var ResourceRegistrar $registrar */
+        $registrar = $this->container->make(ResourceRegistrar::class);
+        $registrar->resource($resourceType, $controller, $options);
+
+        return $registrar;
+    }
+
+    /**
+     * Register a resource type with the router and include to the Eloquent adapter.
+     *
+     * @param string $resourceType
+     * @param string $model
+     * @param string $keyName
+     * @param string|null $controller
+     * @param array $options
+     * @return ResourceRegistrar
+     */
+    public function eloquentAdapter($resourceType, $model, $keyName = NULL, $controller = null, array $options = [])
+    {
+        // Include resource type to Eloquent adapter
+        $adapter = $this->container->make(EloquentAdapter::class);
+        $adapter->addResource($resourceType, $model, $keyName);
+
         /** @var ResourceRegistrar $registrar */
         $registrar = $this->container->make(ResourceRegistrar::class);
         $registrar->resource($resourceType, $controller, $options);


### PR DESCRIPTION
This feature allow register adapters in the routes PHP file when you define JSON API resources. This feature avoid use a configuration file for register adapters and/or Eloquent adapter mappings. Example:

```
Route::group([
    'middleware' => ['api-v1'],
    'namespace' => 'Api',
    'prefix' => 'api/v1',
    'as' => 'api-v1::'
], function () {
    JsonApi::eloquentAdapter('comments', 'App\Comment');
    JsonApi::eloquentAdapter('people', 'App\Person');
    JsonApi::eloquentAdapter('posts', 'App\Post');
    JsonApi::adapter('sites', 'App\JsonApi\Sites\Adapter');
});
```