### PR TITLE
Get default attributes for schemas and hydrators from model fillable attribute

### DIFF
--- a/src/Hydrator/EloquentHydrator.php
+++ b/src/Hydrator/EloquentHydrator.php
@@ -70,7 +70,7 @@ class EloquentHydrator extends AbstractHydrator implements HydratesRelatedInterf
      *
      * @var array
      */
-    protected $attributes = [];
+    protected $attributes = NULL;
 
     /**
      * The resource attributes that are dates.
@@ -117,29 +117,21 @@ class EloquentHydrator extends AbstractHydrator implements HydratesRelatedInterf
     }
     
     /**
-     * @param StandardObjectInterface $attributes
      * @param $record
      * @return void
      */
-    protected function defaultHydrateAttributes(StandardObjectInterface $attributes, $record)
+    protected function attributeKeys($record)
     {
-        $hydratorAttributes = $this->attributes;
-        if(empty($hydratorAttributes))
+        if(is_null($this->attributes))
         {
-            $hydratorAttributes = [];
+            $fillableAttributes = [];
             foreach($record->getFillable() as $attribute)
             {
-                if(strpos($attribute, '_') !== false)
-                {
-                    $hydratorAttributes[str_replace('_', '-', $attribute)] = $attribute;
-                }
-                else
-                {
-                    $hydratorAttributes[] = $attribute;
-                }
+                $fillableAttributes[Str::dasherize($attribute)] = $attribute;
             }
+            return $fillableAttributes;
         }
-        return $hydratorAttributes;
+        return $this->attributes;
     }
 
     /**
@@ -153,7 +145,7 @@ class EloquentHydrator extends AbstractHydrator implements HydratesRelatedInterf
 
         $data = [];
 
-        foreach ($this->defaultHydrateAttributes($attributes, $record) as $resourceKey => $modelKey) {
+        foreach ($this->attributeKeys($record) as $resourceKey => $modelKey) {
             if (is_numeric($resourceKey)) {
                 $resourceKey = $modelKey;
                 $modelKey = $this->keyForAttribute($modelKey, $record);

--- a/src/Hydrator/EloquentHydrator.php
+++ b/src/Hydrator/EloquentHydrator.php
@@ -115,6 +115,32 @@ class EloquentHydrator extends AbstractHydrator implements HydratesRelatedInterf
     {
         $this->service = $service;
     }
+    
+    /**
+     * @param StandardObjectInterface $attributes
+     * @param $record
+     * @return void
+     */
+    protected function defaultHydrateAttributes(StandardObjectInterface $attributes, $record)
+    {
+        $hydratorAttributes = $this->attributes;
+        if(empty($hydratorAttributes))
+        {
+            $hydratorAttributes = [];
+            foreach($record->getFillable() as $attribute)
+            {
+                if(strpos($attribute, '_') !== false)
+                {
+                    $hydratorAttributes[str_replace('_', '-', $attribute)] = $attribute;
+                }
+                else
+                {
+                    $hydratorAttributes[] = $attribute;
+                }
+            }
+        }
+        return $hydratorAttributes;
+    }
 
     /**
      * @inheritDoc
@@ -127,7 +153,7 @@ class EloquentHydrator extends AbstractHydrator implements HydratesRelatedInterf
 
         $data = [];
 
-        foreach ($this->attributes as $resourceKey => $modelKey) {
+        foreach ($this->defaultHydrateAttributes($attributes, $record) as $resourceKey => $modelKey) {
             if (is_numeric($resourceKey)) {
                 $resourceKey = $modelKey;
                 $modelKey = $this->keyForAttribute($modelKey, $record);

--- a/src/Schema/EloquentSchema.php
+++ b/src/Schema/EloquentSchema.php
@@ -155,6 +155,23 @@ abstract class EloquentSchema extends AbstractSchema
     }
 
     /**
+     * Get attributes for the provided model using fillable attribute.
+     *
+     * @param Model $model
+     * @return array
+     */
+    protected function getDefaultModelAttributes(Model $model)
+    {
+        $schemaAttributes = $this->attributes;
+        if(empty($schemaAttributes))
+        {
+            $schemaAttributes = $model->getFillable();
+        }
+        return $schemaAttributes;
+    }
+
+
+    /**
      * Get attributes for the provided model.
      *
      * @param Model $model
@@ -164,7 +181,7 @@ abstract class EloquentSchema extends AbstractSchema
     {
         $attributes = [];
 
-        foreach ($this->attributes as $modelKey => $attributeKey) {
+        foreach ($this->getDefaultModelAttributes($model) as $modelKey => $attributeKey) {
             if (is_numeric($modelKey)) {
                 $modelKey = $attributeKey;
                 $attributeKey = $this->keyForAttribute($attributeKey);

--- a/src/Schema/EloquentSchema.php
+++ b/src/Schema/EloquentSchema.php
@@ -82,7 +82,7 @@ abstract class EloquentSchema extends AbstractSchema
      *
      * @var array
      */
-    protected $attributes = [];
+    protected $attributes = NULL;
 
     /**
      * Whether resource member names are hyphenated
@@ -160,14 +160,17 @@ abstract class EloquentSchema extends AbstractSchema
      * @param Model $model
      * @return array
      */
-    protected function getDefaultModelAttributes(Model $model)
+    protected function attributeKeys(Model $model)
     {
-        $schemaAttributes = $this->attributes;
-        if(empty($schemaAttributes))
+        if(is_null($this->attributes))
         {
-            $schemaAttributes = $model->getFillable();
+            if(! empty($model->getVisible()))
+            {
+                return $model->getVisible();
+            }
+            return array_diff($model->getFillable(), $model->getHidden());
         }
-        return $schemaAttributes;
+        return $this->attributes;
     }
 
 
@@ -181,7 +184,7 @@ abstract class EloquentSchema extends AbstractSchema
     {
         $attributes = [];
 
-        foreach ($this->getDefaultModelAttributes($model) as $modelKey => $attributeKey) {
+        foreach ($this->attributeKeys($model) as $modelKey => $attributeKey) {
             if (is_numeric($modelKey)) {
                 $modelKey = $attributeKey;
                 $attributeKey = $this->keyForAttribute($attributeKey);


### PR DESCRIPTION
This implementation uses fillable attributes from eloquent models to avoid repetition of these attributes declaration in the schema and hydrator classes (by default, if attributes are declared in schema/hydrator class, these are used).