### PR TITLE
Management timezones in hydrator

### DIFF
--- a/src/Hydrator/EloquentHydrator.php
+++ b/src/Hydrator/EloquentHydrator.php
@@ -70,21 +70,21 @@ class EloquentHydrator extends AbstractHydrator implements HydratesRelatedInterf
      *
      * @var array
      */
-    protected $attributes = NULL;
+    protected $attributes = null;
 
     /**
      * The resource attributes that are dates.
      *
      * @var string[]
      */
-    protected $dates = NULL;
+    protected $dates = null;
 
     /**
      * Indicates timezone to use for save dates in database.
      *
      * @var string
      */
-    protected $timezone = NULL;
+    protected $timezone = null;
 
     /**
      * Resource relationship keys that should be automatically hydrated.
@@ -124,16 +124,18 @@ class EloquentHydrator extends AbstractHydrator implements HydratesRelatedInterf
     }
     
     /**
-     * @param $record
-     * @return void
+     * @param StandardObjectInterface $attributes
+     *      the attributes received from the client.
+     * @param Model $record
+     *      the model being hydrated
+     * @return array
+     *      the JSON API attribute keys to hydrate
      */
-    protected function attributeKeys($record)
+    protected function attributeKeys(StandardObjectInterface $attributes, $record)
     {
-        if(is_null($this->attributes))
-        {
+        if (is_null($this->attributes)) {
             $fillableAttributes = [];
-            foreach($record->getFillable() as $attribute)
-            {
+            foreach ($record->getFillable() as $attribute) {
                 $fillableAttributes[Str::dasherize($attribute)] = $attribute;
             }
             return $fillableAttributes;
@@ -152,7 +154,7 @@ class EloquentHydrator extends AbstractHydrator implements HydratesRelatedInterf
 
         $data = [];
 
-        foreach ($this->attributeKeys($record) as $resourceKey => $modelKey) {
+        foreach ($this->attributeKeys($attributes, $record) as $resourceKey => $modelKey) {
             if (is_numeric($resourceKey)) {
                 $resourceKey = $modelKey;
                 $modelKey = $this->keyForAttribute($modelKey, $record);

--- a/src/Hydrator/EloquentHydrator.php
+++ b/src/Hydrator/EloquentHydrator.php
@@ -80,6 +80,13 @@ class EloquentHydrator extends AbstractHydrator implements HydratesRelatedInterf
     protected $dates = NULL;
 
     /**
+     * Indicates timezone to use for save dates in database.
+     *
+     * @var string
+     */
+    protected $timezone = NULL;
+
+    /**
      * Resource relationship keys that should be automatically hydrated.
      *
      * This hydrator can hydrate Eloquent `BelongsTo` and `BelongsToMany` relationships. To do so,
@@ -266,7 +273,14 @@ class EloquentHydrator extends AbstractHydrator implements HydratesRelatedInterf
      */
     protected function deserializeDate($value)
     {
-        return !is_null($value) ? new Carbon($value) : null;
+        $date = null;
+
+        if (!is_null($value))
+        {
+            $date = is_null($this->timezone) ? new Carbon($value) : (new Carbon($value))->setTimezone($this->timezone);
+        }
+
+        return $date;
     }
 
     /**

--- a/src/Schema/EloquentSchema.php
+++ b/src/Schema/EloquentSchema.php
@@ -82,7 +82,7 @@ abstract class EloquentSchema extends AbstractSchema
      *
      * @var array
      */
-    protected $attributes = NULL;
+    protected $attributes = null;
 
     /**
      * Whether resource member names are hyphenated
@@ -162,17 +162,14 @@ abstract class EloquentSchema extends AbstractSchema
      */
     protected function attributeKeys(Model $model)
     {
-        if(is_null($this->attributes))
-        {
-            if(! empty($model->getVisible()))
-            {
+        if (is_null($this->attributes)) {
+            if (!empty($model->getVisible())) {
                 return $model->getVisible();
             }
             return array_diff($model->getFillable(), $model->getHidden());
         }
         return $this->attributes;
     }
-
 
     /**
      * Get attributes for the provided model.


### PR DESCRIPTION
Now, if i make a POST to API with this field:

```"field_datetime": "2017-03-06T12:30:00+01:00"```

The API return me this:

```"field_datetime": "2017-03-06T12:30:00+00:00"```

It's because the MySQL column is a datetime and it hasn't timezone control.

With this PR we offer the possibility the define the timezone (by default NULL, it means to don't use this feature) in order to convert the datetime before save in database.

Maybe the schema would be modify to offer the possibility of transform the datetimes in database to the correct timezone before return this fields.

We always save the datetimes in `Etc/UTC`, and we only need this modification. If you want, we can modify Eloquent Schema in order to allow management timezones too.