### PR TITLE
Use Orchestra Testbench for integration tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
     },
     "require-dev": {
         "illuminate/routing": "5.4.*",
+        "orchestra/testbench": "~3.0",
         "phpunit/phpunit": "^5.7"
     },
     "autoload": {

--- a/tests/Integration/Routing/ResourceRegistrarTest.php
+++ b/tests/Integration/Routing/ResourceRegistrarTest.php
@@ -26,11 +26,11 @@ use CloudCreativity\LaravelJsonApi\Api\Repository;
 use CloudCreativity\LaravelJsonApi\Api\ResourceProviders;
 use CloudCreativity\LaravelJsonApi\Routing\ApiGroup as Api;
 use CloudCreativity\LaravelJsonApi\Routing\ResourceRegistrar;
+use CloudCreativity\LaravelJsonApi\Tests\Integration\TestCase;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Route;
 use Illuminate\Routing\Router;
-use PHPUnit\Framework\TestCase;
 use PHPUnit_Framework_MockObject_MockObject as Mock;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -64,7 +64,7 @@ class ResourceRegistrarTest extends TestCase
      */
     private $resources;
 
-    protected function setUp()
+    public function setUp()
     {
         $this->definition = $this->getMockBuilder(Definition::class)->disableOriginalConstructor()->getMock();
         $this->definition

--- a/tests/Integration/TestCase.php
+++ b/tests/Integration/TestCase.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * Copyright 2017 Cloud Creativity Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace CloudCreativity\LaravelJsonApi\Tests\Integration;
+
+
+/**
+ * Class TestCase
+ *
+ * @package CloudCreativity\LaravelJsonApi\Tests\Integration
+ */
+abstract class TestCase extends \Orchestra\Testbench\TestCase
+{
+    protected function getPackageProviders($app)
+    {
+        return [
+            \CloudCreativity\LaravelJsonApi\ServiceProvider::class,
+        ];
+    }
+
+    protected function getPackageAliases($app)
+    {
+        return [
+            'JsonApi' => \CloudCreativity\LaravelJsonApi\Facade::class,
+        ];
+    }
+
+}


### PR DESCRIPTION
### What needs to be done
- [x] Pull in orchestra testbench
- [x] Setup an abstract TestCase that pre-configures:
  - [x] Service provider
  - [x] Facade/alias
- [x] Make existing integration tests extend the new Orchestral test case, rather than stock PHPUnit_TestCase

### Why the change
The Testbench project by Orchestral makes testing features that are tightly integrated with the Laravel framework a breeze. This allows for a hazzle-free testing environment, that might motivate writing more integration tests.