### PR TITLE
Adding in a prompt to clear the config cache

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -33,6 +33,12 @@ Then publish the package config file:
 $ php artisan vendor:publish --provider="CloudCreativity\LaravelJsonApi\ServiceProvider"
 ```
 
+You may then need to clear the cache config:
+
+``` bash
+$ php artisan cache:clear
+```
+
 ## Exception Handling
 
 Parts of the package throw exceptions to abort execution and render JSON API errors. Your will therefore need to


### PR DESCRIPTION
I couldn't run the make:json-api command on the next page because I needed to clear the config cache, this is probably useful to have written down.