### PR TITLE
Adding in a config cache

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -20,6 +20,14 @@ $ php artisan make:json-api v1
 
 Will create the `json-api-v1.php` file.
 
+### Clear your cache
+
+Once you've generated your APIs you'll need to re-cache your config.
+
+``` bash
+$ php artisan config:cache
+```
+
 ## Defining Resources
 
 Your API must be configured to understand how a JSON API resource type maps to a PHP class within your application. This is defined in the `resources` setting in the API's configuration file.


### PR DESCRIPTION
This one is needed as later on when I tried to generate my controllers for the resources it wouldn't work because the api namespace wasn't recognised as the newly generated configuration files hadn't been pulled into the config cache.