### PR TITLE
[Feature] Preserve Floats

### DIFF
--- a/stubs/api.php
+++ b/stubs/api.php
@@ -38,7 +38,7 @@ return [
     | `'posts' => App\Post::class`
     */
     'resources' => [
-        'posts' => 'App\Post',
+        'posts' => App\Post::class,
     ],
 
     /*

--- a/stubs/api.php
+++ b/stubs/api.php
@@ -106,7 +106,7 @@ return [
     'codecs' => [
         'encoders' => [
             'application/vnd.api+json',
-            'text/plain' => JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES,
+            'text/plain' => JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_PRESERVE_ZERO_FRACTION,
         ],
         'decoders' => [
             'application/vnd.api+json',


### PR DESCRIPTION
I heard a lot of lovely things about this package! Thanks for all of the hard work.
With this pull request I added `JSON_PRESERVE_ZERO_FRACTION` to the default api config stub file.
In many situtations its preferred by clients (consumers of an API) to distinguish between actual floats or integers.