### PR TITLE
Explict Allowed Include Paths

### DIFF
--- a/src/Http/Query/ChecksQueryParameters.php
+++ b/src/Http/Query/ChecksQueryParameters.php
@@ -54,11 +54,7 @@ trait ChecksQueryParameters
      */
     protected function allowedIncludePaths()
     {
-        if (property_exists($this, 'allowedIncludePaths')) {
-            return $this->allowedIncludePaths;
-        }
-
-        return [];
+        $this->allowedIncludePaths;
     }
 
     /**

--- a/src/Http/Query/ChecksQueryParameters.php
+++ b/src/Http/Query/ChecksQueryParameters.php
@@ -54,7 +54,7 @@ trait ChecksQueryParameters
      */
     protected function allowedIncludePaths()
     {
-        $this->allowedIncludePaths;
+        return $this->allowedIncludePaths;
     }
 
     /**

--- a/src/Validators/AbstractValidatorProvider.php
+++ b/src/Validators/AbstractValidatorProvider.php
@@ -86,6 +86,18 @@ abstract class AbstractValidatorProvider implements ValidatorProviderInterface
     protected $queryCustomAttributes = [];
 
     /**
+     * The allowed include paths.
+     *
+     * By default all relationship includes are disabled. By filling the keys of the
+     * relationships you can allow specific relations to be included.
+     *
+     * @example /api/v1/posts/1?include=author
+     *
+     * @var array
+     */
+    protected $allowedIncludePaths = [];
+
+    /**
      * The allowed filtering parameters.
      *
      * By default we set this to `null` to allow any filtering parameters, as we expect

--- a/stubs/independent/validators.stub
+++ b/stubs/independent/validators.stub
@@ -14,6 +14,18 @@ class Validators extends AbstractValidatorProvider
     protected $resourceType = 'dummyResourceType';
 
     /**
+     * The allowed include paths.
+     *
+     * By default all relationship includes are disabled. By filling the keys of the
+     * relationships you can allow specific relations to be included.
+     *
+     * @example /api/v1/posts/1?include=author
+     *
+     * @var array
+     */
+    protected $allowedIncludePaths = [];
+
+    /**
      * Get the validation rules for the resource attributes.
      *
      * @param object|null $record


### PR DESCRIPTION
Hi,

Sorry for all the PRs.

Currently it is not clear why an error is returned when trying to fetch a defined relationship.

After some searching, I discovered that the `resourceQueryChecker` is responsible for this. It checks for the property  `allowedIncludePaths` which is not documented anywhere.

This PR solves this problem by adding the property `allowedIncludePaths` to the `AbstractValidatorProvider` and Validator stub file. It makes it also easier to start using the package right away.

It also removes the `property_exists` check which results in a very small performance boost. 😃 