### PR TITLE
Improve compatibility with Laravel’s HTTP test API

### DIFF
--- a/src/Utils/Helpers.php
+++ b/src/Utils/Helpers.php
@@ -80,6 +80,10 @@ class Helpers
             return false;
         }
 
+        if((string) $request->getBody() === '[]'){
+            return false;
+        }
+
         return 0 < $contentLength[0];
     }
 


### PR DESCRIPTION
Laravel’s built-in HTTP Tests API sends a body for GET requests of `[]`.

This causes a JSON parsing failure as it’s not recognized as an object. It _should_ be recognized as an empty body, but it’s not. Adjusting this helper method fixes the issue while not causing any regressions in the test suite.