### PR TITLE
Resolve API url generation issues for subdirectory installs.

### DIFF
--- a/src/Http/Middleware/BootJsonApi.php
+++ b/src/Http/Middleware/BootJsonApi.php
@@ -75,7 +75,7 @@ class BootJsonApi
         $serverRequest = $this->container->make(ServerRequestInterface::class);
 
         /** Build and register the API */
-        $api = $this->bindApi($namespace, $request->getSchemeAndHttpHost());
+        $api = $this->bindApi($namespace, $request->getSchemeAndHttpHost() . $request->getBaseUrl());
 
         /** Do content negotiation. */
         $this->doContentNegotiation($factory, $serverRequest, $api->getCodecMatcher());


### PR DESCRIPTION
Concatenating `$request->getSchemeAndHttpHost()` with  `$request->getBaseUrl()` generates the correct URLs for subdirectory installs. I have tested this works with a Laravel 5.4 installation in both the root directory and a subdirectory.