### PR TITLE
Do not dasherize resource type and relationship in route url

### DIFF
--- a/src/Routing/RegistersResources.php
+++ b/src/Routing/RegistersResources.php
@@ -65,7 +65,7 @@ trait RegistersResources
      */
     protected function relatedUrl($relationship)
     {
-        return sprintf('%s/%s', $this->resourceUrl(), Str::dasherize($relationship));
+        return sprintf('%s/%s', $this->resourceUrl(), $relationship);
     }
 
     /**
@@ -78,7 +78,7 @@ trait RegistersResources
             '%s/%s/%s',
             $this->resourceUrl(),
             ResourceRegistrar::KEYWORD_RELATIONSHIPS,
-            Str::dasherize($relationship)
+            $relationship
         );
     }
 

--- a/src/Routing/ResourceGroup.php
+++ b/src/Routing/ResourceGroup.php
@@ -19,7 +19,6 @@
 namespace CloudCreativity\LaravelJsonApi\Routing;
 
 use CloudCreativity\LaravelJsonApi\Contracts\Resolver\ResolverInterface;
-use CloudCreativity\LaravelJsonApi\Utils\Str;
 use Illuminate\Contracts\Routing\Registrar;
 use Illuminate\Routing\Route;
 use Illuminate\Support\Fluent;
@@ -77,7 +76,7 @@ class ResourceGroup
         return [
             'middleware' => $this->middleware(),
             'as' => "{$this->resourceType}.",
-            'prefix' => Str::dasherize($this->resourceType),
+            'prefix' => $this->resourceType,
         ];
     }
 

--- a/tests/lib/Integration/Issue224/IssueTest.php
+++ b/tests/lib/Integration/Issue224/IssueTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace CloudCreativity\LaravelJsonApi\Tests\Integration\Issue224;
+
+use CloudCreativity\LaravelJsonApi\Facades\JsonApi;
+use CloudCreativity\LaravelJsonApi\Routing\ApiGroup;
+use CloudCreativity\LaravelJsonApi\Tests\Integration\TestCase;
+use DummyApp\JsonApi\Users\Adapter;
+use DummyApp\User;
+use Illuminate\Support\Facades\Route;
+
+class IssueTest extends TestCase
+{
+
+    /**
+     * @var bool
+     */
+    protected $appRoutes = false;
+
+    /**
+     * @var string
+     */
+    protected $resourceType = 'endUsers';
+
+    /**
+     * @return void
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->app->bind('DummyApp\\JsonApi\\EndUsers\\Adapter', Adapter::class);
+        $this->app->bind('DummyApp\\JsonApi\\EndUsers\\Schema', Schema::class);
+
+        Route::group([
+            'namespace' => 'DummyApp\\Http\\Controllers',
+        ], function () {
+            JsonApi::register('v1', [], function (ApiGroup $api) {
+                $api->resource('endUsers');
+            });
+        });
+
+        $this->refreshRoutes();
+
+        config()->set('json-api-v1.resources', [
+            'endUsers' => User::class,
+        ]);
+    }
+
+    public function test()
+    {
+        $user = factory(User::class)->create();
+
+        $this->getJsonApi("/api/v1/endUsers/{$user->getRouteKey()}")->assertRead([
+            'type' => 'endUsers',
+            'id' => $user->getRouteKey(),
+            'attributes' => [
+                'name' => $user->name,
+            ],
+        ]);
+    }
+}

--- a/tests/lib/Integration/Issue224/Schema.php
+++ b/tests/lib/Integration/Issue224/Schema.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace CloudCreativity\LaravelJsonApi\Tests\Integration\Issue224;
+
+use Neomerx\JsonApi\Schema\SchemaProvider;
+
+class Schema extends SchemaProvider
+{
+
+    /**
+     * @var string
+     */
+    protected $resourceType = 'endUsers';
+
+    /**
+     * @inheritdoc
+     */
+    public function getId($resource)
+    {
+        return $resource->getRouteKey();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getAttributes($resource)
+    {
+        return [
+            'name' => $resource->name,
+        ];
+    }
+
+}

--- a/tests/lib/Unit/Resolver/NamespaceResolverTest.php
+++ b/tests/lib/Unit/Resolver/NamespaceResolverTest.php
@@ -70,6 +70,14 @@ class NamespaceResolverTest extends TestCase
                 'App\JsonApi\DanceEvents\Validators',
                 'App\JsonApi\DanceEvents\Authorizer',
             ],
+            [
+                'danceEvents',
+                null,
+                'App\JsonApi\DanceEvents\Schema',
+                'App\JsonApi\DanceEvents\Adapter',
+                'App\JsonApi\DanceEvents\Validators',
+                'App\JsonApi\DanceEvents\Authorizer',
+            ],
         ];
     }
 
@@ -113,6 +121,14 @@ class NamespaceResolverTest extends TestCase
             ],
             [
                 'dance_events',
+                null,
+                'App\JsonApi\Schemas\DanceEventSchema',
+                'App\JsonApi\Adapters\DanceEventAdapter',
+                'App\JsonApi\Validators\DanceEventValidator',
+                'App\JsonApi\Authorizers\DanceEventAuthorizer',
+            ],
+            [
+                'danceEvents',
                 null,
                 'App\JsonApi\Schemas\DanceEventSchema',
                 'App\JsonApi\Adapters\DanceEventAdapter',
@@ -168,6 +184,14 @@ class NamespaceResolverTest extends TestCase
                 'App\JsonApi\Validators\DanceEvent',
                 'App\JsonApi\Authorizers\DanceEvent',
             ],
+            [
+                'danceEvents',
+                null,
+                'App\JsonApi\Schemas\DanceEvent',
+                'App\JsonApi\Adapters\DanceEvent',
+                'App\JsonApi\Validators\DanceEvent',
+                'App\JsonApi\Authorizers\DanceEvent',
+            ],
         ];
     }
 
@@ -181,14 +205,17 @@ class NamespaceResolverTest extends TestCase
             ['generic', 'App\JsonApi\GenericAuthorizer', true],
             ['foo-bar', 'App\JsonApi\FooBarAuthorizer', true],
             ['foo_bar', 'App\JsonApi\FooBarAuthorizer', true],
+            ['fooBar', 'App\JsonApi\FooBarAuthorizer', true],
             // Not by resource
             ['generic', 'App\JsonApi\Authorizers\GenericAuthorizer', false],
             ['foo-bar', 'App\JsonApi\Authorizers\FooBarAuthorizer', false],
             ['foo_bar', 'App\JsonApi\Authorizers\FooBarAuthorizer', false],
+            ['fooBar', 'App\JsonApi\Authorizers\FooBarAuthorizer', false],
             // Not by resource without type appended:
             ['generic', 'App\JsonApi\Authorizers\Generic', false, false],
             ['foo-bar', 'App\JsonApi\Authorizers\FooBar', false, false],
             ['foo_bar', 'App\JsonApi\Authorizers\FooBar', false, false],
+            ['fooBar', 'App\JsonApi\Authorizers\FooBar', false, false],
         ];
     }
 


### PR DESCRIPTION
Use the resource type and relationship name as provided - so that it can be camel case or snake case.

See #224