### PR TITLE
Fixing syntax highlighting and layout in docs

### DIFF
--- a/docs/fetching/filtering.md
+++ b/docs/fetching/filtering.md
@@ -60,7 +60,7 @@ If your resource does not support filtering, you should reject any request that 
 parameter. You can do this by disallowing filtering parameters on your [Validators](../basics/validators.md)
 class as follows:
 
-```php****
+```php
 class Validators extends AbstractValidators
 {
     // ...


### PR DESCRIPTION
While reading the library docs on readthedocs I saw the layout for fetching/filtering is a bit broken and syntax highlighting does not work.

![jsonapi](https://user-images.githubusercontent.com/2538064/47786570-6e057e80-dd0c-11e8-996f-7884bd34b155.png)

This PR should fix it.
