### PR TITLE
[Refactor] Make adapter read method consistent

### DIFF
--- a/docs/basics/adapters.md
+++ b/docs/basics/adapters.md
@@ -655,6 +655,20 @@ class Adapter extends AbstractAdapter
 }
 ```
 
+Or if your resource uses a client-generated ID, you can assign the id in the `creating` hook:
+
+```php
+class Adapter extends AbstractAdapter
+{
+    // ...
+    
+    protected function creating(Comment $comment, $resource): void
+    {
+        $comment->{$comment->getRouteKeyName()} = $resource['id']; 
+    }
+}
+```
+
 There are two additional hooks that are invoked when an adapter is deleting a resource: `deleting` and `deleted`.
 These receive the record being deleted as the first function argument.
 

--- a/src/Adapter/AbstractResourceAdapter.php
+++ b/src/Adapter/AbstractResourceAdapter.php
@@ -95,9 +95,9 @@ abstract class AbstractResourceAdapter implements ResourceAdapterInterface, Stor
     /**
      * @inheritDoc
      */
-    public function read($resourceId, EncodingParametersInterface $parameters)
+    public function read($record, EncodingParametersInterface $parameters)
     {
-        return $this->find($resourceId);
+        return $record;
     }
 
     /**

--- a/src/Contracts/Adapter/ResourceAdapterInterface.php
+++ b/src/Contracts/Adapter/ResourceAdapterInterface.php
@@ -55,11 +55,12 @@ interface ResourceAdapterInterface
     /**
      * Query a single domain record.
      *
-     * @param string $resourceId
+     * @param mixed $record
+     *      the domain record being read.
      * @param EncodingParametersInterface $parameters
      * @return mixed|null
      */
-    public function read($resourceId, EncodingParametersInterface $parameters);
+    public function read($record, EncodingParametersInterface $parameters);
 
     /**
      * Update a domain record with data from the supplied resource object.

--- a/src/Contracts/Store/StoreInterface.php
+++ b/src/Contracts/Store/StoreInterface.php
@@ -74,12 +74,12 @@ interface StoreInterface
     /**
      * Query the store for a single record using the supplied parameters.
      *
-     * @param string $resourceType
-     * @param string $resourceId
+     * @param object $record
+     *      the domain record being read.
      * @param EncodingParametersInterface $params
      * @return object|null
      */
-    public function readRecord($resourceType, $resourceId, EncodingParametersInterface $params);
+    public function readRecord($record, EncodingParametersInterface $params);
 
     /**
      * Update a domain record with data from the supplied resource object.

--- a/src/Eloquent/AbstractAdapter.php
+++ b/src/Eloquent/AbstractAdapter.php
@@ -182,15 +182,13 @@ abstract class AbstractAdapter extends AbstractResourceAdapter
     /**
      * @inheritDoc
      */
-    public function read($resourceId, EncodingParametersInterface $parameters)
+    public function read($record, EncodingParametersInterface $parameters)
     {
         $parameters = $this->getQueryParameters($parameters);
 
         if (!empty($parameters->getFilteringParameters())) {
-            return $this->readWithFilters($resourceId, $parameters);
+            $record = $this->readWithFilters($record, $parameters);
         }
-
-        $record = parent::read($resourceId, $parameters);
 
         if ($record) {
             $this->load($record, $parameters);
@@ -275,17 +273,18 @@ abstract class AbstractAdapter extends AbstractResourceAdapter
     }
 
     /**
-     * Read by resource id and filters.
+     * Does the record match the supplied filters?
      *
-     * @param $resourceId
+     * @param Model $record
      * @param EncodingParametersInterface $parameters
-     * @return Model
+     * @return Model|null
      */
-    protected function readWithFilters($resourceId, EncodingParametersInterface $parameters)
+    protected function readWithFilters($record, EncodingParametersInterface $parameters)
     {
-        $query = $this->newQuery()->where($this->getQualifiedKeyName(), $resourceId);
+        $query = $this->newQuery()->whereKey($record->getKey());
+        $this->applyFilters($query, collect($parameters->getFilteringParameters()));
 
-        return $this->queryOne($query, $parameters);
+        return $query->exists() ? $record : null;
     }
 
     /**

--- a/src/Http/Controllers/JsonApiController.php
+++ b/src/Http/Controllers/JsonApiController.php
@@ -93,8 +93,7 @@ class JsonApiController extends Controller
     public function read(StoreInterface $store, FetchResource $request)
     {
         $record = $store->readRecord(
-            $request->getResourceType(),
-            $request->getResourceId(),
+            $request->getRecord(),
             $request->getParameters()
         );
 
@@ -308,8 +307,7 @@ class JsonApiController extends Controller
     public function process(StoreInterface $store, FetchProcess $request)
     {
         $record = $store->readRecord(
-            $request->getProcessType(),
-            $request->getProcessId(),
+            $request->getProcess(),
             $request->getEncodingParameters()
         );
 

--- a/src/Http/Requests/FetchProcess.php
+++ b/src/Http/Requests/FetchProcess.php
@@ -17,6 +17,7 @@
 
 namespace CloudCreativity\LaravelJsonApi\Http\Requests;
 
+use CloudCreativity\LaravelJsonApi\Contracts\Queue\AsynchronousProcess;
 use CloudCreativity\LaravelJsonApi\Contracts\Validators\ValidatorProviderInterface;
 
 /**
@@ -33,6 +34,14 @@ class FetchProcess extends FetchProcesses
     public function getProcessId(): string
     {
         return $this->jsonApiRequest->getProcessId();
+    }
+
+    /**
+     * @return AsynchronousProcess|null
+     */
+    public function getProcess(): ?AsynchronousProcess
+    {
+        return $this->jsonApiRequest->getProcess();
     }
 
     /**

--- a/src/Http/Requests/JsonApiRequest.php
+++ b/src/Http/Requests/JsonApiRequest.php
@@ -18,6 +18,7 @@
 namespace CloudCreativity\LaravelJsonApi\Http\Requests;
 
 use CloudCreativity\LaravelJsonApi\Contracts\Object\ResourceIdentifierInterface;
+use CloudCreativity\LaravelJsonApi\Contracts\Queue\AsynchronousProcess;
 use CloudCreativity\LaravelJsonApi\Contracts\Resolver\ResolverInterface;
 use CloudCreativity\LaravelJsonApi\Exceptions\InvalidJsonException;
 use CloudCreativity\LaravelJsonApi\Exceptions\RuntimeException;
@@ -217,6 +218,16 @@ class JsonApiRequest
         }
 
         return $this->processId ?: null;
+    }
+
+    /**
+     * @return AsynchronousProcess|null
+     */
+    public function getProcess(): ?AsynchronousProcess
+    {
+        $process = $this->request->route(ResourceRegistrar::PARAM_PROCESS_ID);
+
+        return ($process instanceof AsynchronousProcess) ? $process : null;
     }
 
     /**

--- a/src/Store/Store.php
+++ b/src/Store/Store.php
@@ -97,17 +97,11 @@ class Store implements StoreInterface
     /**
      * @inheritDoc
      */
-    public function readRecord($resourceType, $resourceId, EncodingParametersInterface $params)
+    public function readRecord($record, EncodingParametersInterface $params)
     {
-        $record = $this
-            ->adapterFor($resourceType)
-            ->read($resourceId, $params);
-
-        if ($record) {
-            $this->identityMap->add(ResourceIdentifier::create($resourceType, $resourceId), $record);
-        }
-
-        return $record;
+        return $this
+            ->adapterFor($record)
+            ->read($record, $params);
     }
 
     /**

--- a/tests/lib/Integration/Eloquent/ResourceTest.php
+++ b/tests/lib/Integration/Eloquent/ResourceTest.php
@@ -211,15 +211,27 @@ class ResourceTest extends TestCase
 
     /**
      * Test the read resource route.
+     *
+     * @see https://github.com/cloudcreativity/laravel-json-api/issues/256
+     *      we only expect to see the model retrieved once.
      */
     public function testRead()
     {
+        $retrieved = 0;
+
+        Post::retrieved(function () use (&$retrieved) {
+            $retrieved++;
+        });
+
+
         $model = $this->createPost();
         $model->tags()->create(['name' => 'Important']);
 
         $this->doRead($model)->assertFetchedOneExact(
             $this->serialize($model)
         );
+
+        $this->assertSame(1, $retrieved, 'retrieved once');
     }
 
     /**

--- a/tests/lib/Integration/FilterTest.php
+++ b/tests/lib/Integration/FilterTest.php
@@ -95,10 +95,19 @@ class FilterTest extends TestCase
      * Must be able to filter a read resource request.
      *
      * @see https://github.com/cloudcreativity/laravel-json-api/issues/218
+     *      for the original issue to add this feature.
+     * @see https://github.com/cloudcreativity/laravel-json-api/issues/256
+     *      we expect the resource to be retrieved once.
      */
     public function testFilterResource()
     {
         $post = factory(Post::class)->states('published')->create();
+
+        $retrieved = 0;
+
+        Post::retrieved(function () use (&$retrieved) {
+            $retrieved++;
+        });
 
         $expected = [
             'type' => 'posts',
@@ -110,7 +119,9 @@ class FilterTest extends TestCase
 
         $this->resourceType = 'posts';
         $this->doRead($post, ['filter' => ['published' => 1]])
-            ->assertSearchedOne($expected);
+            ->assertFetchedOne($expected);
+
+        $this->assertSame(1, $retrieved, 'retrieved once');
     }
 
     public function testFilterResourceDoesNotMatch()

--- a/tests/lib/Unit/Store/StoreTest.php
+++ b/tests/lib/Unit/Store/StoreTest.php
@@ -114,22 +114,12 @@ class StoreTest extends TestCase
         $params = new EncodingParameters();
         $expected = new \stdClass();
 
-        $store = $this->store([
-            'posts' => $this->willNotQuery(),
-            'comments' => $this->willReadRecord('1', $params, $expected)
+        $store = $this->storeByTypes([
+            \DateTime::class => $this->willNotQuery(),
+            \stdClass::class => $this->willReadRecord($expected, $params),
         ]);
 
-        $this->assertSame($expected, $store->readRecord('comments', '1', $params));
-    }
-
-    /**
-     * If there is no adapter for the resource type, an exception must be thrown.
-     */
-    public function testCannotReadRecord()
-    {
-        $store = $this->store(['posts' => $this->willNotQuery()]);
-        $this->expectException(RuntimeException::class);
-        $store->readRecord('users', '1', new EncodingParameters());
+        $this->assertSame($expected, $store->readRecord($expected, $params));
     }
 
     public function testUpdateRecord()
@@ -631,24 +621,24 @@ class StoreTest extends TestCase
     }
 
     /**
-     * @param $resourceId
-     * @param $params
      * @param $record
+     * @param $params
      * @return MockObject
      */
-    private function willReadRecord($resourceId, $params, $record)
+    private function willReadRecord($record, $params)
     {
         $mock = $this->adapter();
 
         $mock->expects($this->atLeastOnce())
             ->method('read')
-            ->with($resourceId, $params)
+            ->with($record, $params)
             ->willReturn($record);
 
         return $mock;
     }
 
     /**
+     * @param $record
      * @param $resourceObject
      * @param $params
      * @param $expected


### PR DESCRIPTION
Previously the adapter read method took the resource ID has its first argument. This was inconsistent with all the other adapter methods that were to do with a specific record, as they all take the record being read as the first argument.

Because the record is already loaded via binding substitution, it also meant the record was being retrieved twice.

This PR fixes this by changing the method signature to receive the loaded record. It still needs to be passed to the adapter because there is other logic to implement - e.g. in the Eloquent adapter it is used for eager-loading based on the include paths, plus checking whether the record matches any supplied filter parameters.

Closes #256 