### PR TITLE
[Feature] Allow decoder wildcard media parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ are not meant to be extended.
 Also added PHP 7 type-hinting to all methods in the abstract class. 
 
 ### Fixed
+- [#265](https://github.com/cloudcreativity/laravel-json-api/issues/265)
+Allow wildcard media type parameters when matching decoders. This enables support for media types that
+include random parameter values, primarily the `multipart/form-data` type that has a `boundary` parameter
+that is unpredictable.
 - [#280](https://github.com/cloudcreativity/laravel-json-api/issues/280)
 Validation error objects for relationship objects now have correct source pointers.
 - [#284](https://github.com/cloudcreativity/laravel-json-api/issues/284)

--- a/docs/features/media-types.md
+++ b/docs/features/media-types.md
@@ -589,6 +589,7 @@ class ContentNegotiator extends BaseContentNegotiator
 {
     protected $decoding = [
         'multipart/form-data' => \App\JsonApi\MultipartDecoder::class,
+        'multipart/form-data; boundary=*' => \App\JsonApi\MultipartDecoder::class,
     ];
 }
 ```
@@ -630,11 +631,12 @@ class ContentNegotiator extends BaseContentNegotiator
      */
     protected function decodingsForResource(?Avatar $avatar): DecodingList
     {
-        $multiPart = Decoding::create('multipart/form-data', new MultipartDecoder());
+        $decoder = new MultipartDecoder();
 
         return $this
             ->decodingMediaTypes()
-            ->when(is_null($avatar), $multiPart);
+            ->when(is_null($avatar), Decoding::create('multipart/form-data', $decoder))
+            ->when(is_null($avatar), Decoding::create('multipart/form-data; boundary=*', $decoder));
     }
 
 }

--- a/tests/dummy/app/JsonApi/Avatars/ContentNegotiator.php
+++ b/tests/dummy/app/JsonApi/Avatars/ContentNegotiator.php
@@ -46,11 +46,10 @@ class ContentNegotiator extends BaseContentNegotiator
      */
     protected function decodingsForResource(?Avatar $avatar): DecodingList
     {
-        $multiPart = Decoding::create('multipart/form-data', new FileDecoder());
-
         return $this
             ->decodingMediaTypes()
-            ->when(is_null($avatar), $multiPart);
+            ->when(is_null($avatar), Decoding::create('multipart/form-data', new FileDecoder()))
+            ->when(is_null($avatar), Decoding::create('multipart/form-data; boundary=*', new FileDecoder()));
     }
 
 }

--- a/tests/dummy/tests/Feature/Avatars/CreateTest.php
+++ b/tests/dummy/tests/Feature/Avatars/CreateTest.php
@@ -27,11 +27,25 @@ class CreateTest extends TestCase
 {
 
     /**
+     * @return array
+     */
+    public function multipartProvider(): array
+    {
+        return [
+            ['multipart/form-data'],
+            ['multipart/form-data; boundary=----WebKitFormBoundary7MA4YWxkTrZu0gW'],
+        ];
+    }
+
+    /**
      * Test that a user can upload an avatar to the API using a standard
      * HTML form post. This means our API must allow a non-JSON API content media type
      * when creating the resource.
+     *
+     * @param string $contentType
+     * @dataProvider multipartProvider
      */
-    public function test(): void
+    public function test(string $contentType): void
     {
         $user = factory(User::class)->create();
         $file = UploadedFile::fake()->create('avatar.jpg');
@@ -45,7 +59,7 @@ class CreateTest extends TestCase
         $response = $this->actingAs($user, 'api')->post(
             '/api/v1/avatars?include=user',
             ['avatar' => $file],
-            ['Content-Type' => 'multipart/form-data', 'Content-Length' => '1']
+            ['Content-Type' => $contentType, 'Content-Length' => '1']
         );
 
         $id = $response


### PR DESCRIPTION
This commit adds temporary support for wildcard parameters for decoding media types. This is needed so that you can accept `multipart/form-data` which will have an unpredictable `boundary` parameter.

This is a temporary solution as `neomerx/json-api:^3.0` adds support for wildcard parameters when matching media types.

See #265 