### PR TITLE
[Bugfix] Add deterministic sort order to standard paging strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ for an example of how to do this on an exception handler.
 - [#329](https://github.com/cloudcreativity/laravel-json-api/issues/329)
 Render JSON API error responses when a codec has matched, but the client has not explicitly
 asked for JSON API response (e.g. asked for `Accept: */*`).
+- [#313](https://github.com/cloudcreativity/laravel-json-api/issues/313)
+Ensure that the standard paging strategy uses the resource identifier so that pages have a
+[deterministic sort order](https://tighten.co/blog/a-cautionary-tale-of-nondeterministic-laravel-pagination).
 
 ## [1.0.1] - 2019-03-12
 

--- a/docs/fetching/pagination.md
+++ b/docs/fetching/pagination.md
@@ -327,16 +327,16 @@ means the most recently created model is the first in the list, and the oldest i
 column is not unique (there could be multiple rows created at the same time), it uses the resource id
 column as a secondary sort order, as the resource id must always be unique.
 
-To change the column that is used for the list order use the `withColumn` method. If you prefer your
-list to be in ascending order, use the `withAscending` method. For example:
+To change the column that is used for the list order use the `withQualifiedColumn` method. If you prefer
+your list to be in ascending order, use the `withAscending` method. For example:
 
 ```php
-$strategy->withColumn('published_at')->withAscending();
+$strategy->withQualfiedColumn('posts.published_at')->withAscending();
 ```
 
 > The Eloquent adapter will always set the secondary column for sort order to the same column that is
 being used for the resource ID. If you are using the cursor strategy in a custom adapter, you will
-need to set the unique column using the `withIdentifierColumn` method. Note that whatever you set the
+need to set the unique column using the `withQualifiedKeyName` method. Note that whatever you set the
 column to, this will mean the client needs to provide the value of that column for the `after` and
 `before` page parameters - so really it should always match whatever you are using for the resource ID.
 

--- a/src/Eloquent/AbstractAdapter.php
+++ b/src/Eloquent/AbstractAdapter.php
@@ -25,8 +25,6 @@ use CloudCreativity\LaravelJsonApi\Contracts\Pagination\PageInterface;
 use CloudCreativity\LaravelJsonApi\Contracts\Pagination\PagingStrategyInterface;
 use CloudCreativity\LaravelJsonApi\Document\ResourceObject;
 use CloudCreativity\LaravelJsonApi\Exceptions\RuntimeException;
-use CloudCreativity\LaravelJsonApi\Pagination\CursorStrategy;
-use CloudCreativity\LaravelJsonApi\Utils\Str;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations;
@@ -432,9 +430,14 @@ abstract class AbstractAdapter extends AbstractResourceAdapter
             throw new RuntimeException('Paging is not supported on adapter: ' . get_class($this));
         }
 
-        /** If using the cursor strategy, we need to set the key name for the cursor. */
-        if ($this->paging instanceof CursorStrategy) {
-            $this->paging->withIdentifierColumn($this->getKeyName());
+        /**
+         * Set the key name on the strategy, so it knows what column is being used
+         * for the resource's ID.
+         *
+         * @todo 2.0 add `withQualifiedKeyName` to the paging strategy interface.
+         */
+        if (method_exists($this->paging, 'withQualifiedKeyName')) {
+            $this->paging->withQualifiedKeyName($this->getQualifiedKeyName());
         }
 
         return $this->paging->paginate($query, $parameters);

--- a/src/Pagination/CursorStrategy.php
+++ b/src/Pagination/CursorStrategy.php
@@ -161,6 +161,27 @@ class CursorStrategy implements PagingStrategyInterface
      *
      * @param $column
      * @return $this
+     * @todo 2.0 pass qualified columns to the cursor builder.
+     */
+    public function withQualifiedColumn($column)
+    {
+        $parts = explode('.', $column);
+
+        if (!isset($parts[1])) {
+            throw new \InvalidArgumentException('Expecting a valid qualified column name.');
+        }
+
+        $this->withColumn($parts[1]);
+
+        return $this;
+    }
+
+    /**
+     * Set the cursor column.
+     *
+     * @param $column
+     * @return $this
+     * @deprecated 2.0 use `withQualifiedColumn` instead.
      */
     public function withColumn($column)
     {
@@ -170,10 +191,31 @@ class CursorStrategy implements PagingStrategyInterface
     }
 
     /**
+     * Set the column name for the resource's ID.
+     *
+     * @param string $keyName
+     * @return $this
+     * @todo 2.0 pass qualified key name to the cursor builder.
+     */
+    public function withQualifiedKeyName($keyName)
+    {
+        $parts = explode('.', $keyName);
+
+        if (!isset($parts[1])) {
+            throw new \InvalidArgumentException('Expecting a valid qualified column name.');
+        }
+
+        $this->withIdentifierColumn($parts[1]);
+
+        return $this;
+    }
+
+    /**
      * Set the column for the before/after identifiers.
      *
      * @param string|null $column
      * @return $this
+     * @deprecated 2.0 use `withQualifiedKeyName` instead.
      */
     public function withIdentifierColumn($column)
     {
@@ -183,6 +225,8 @@ class CursorStrategy implements PagingStrategyInterface
     }
 
     /**
+     * Set the select columns for the query.
+     *
      * @param $cols
      * @return $this
      */

--- a/tests/dummy/app/JsonApi/Posts/Validators.php
+++ b/tests/dummy/app/JsonApi/Posts/Validators.php
@@ -28,6 +28,7 @@ class Validators extends AbstractValidators
      * @var array
      */
     protected $allowedSortParameters = [
+        'id',
         'created-at',
         'updated-at',
         'title',

--- a/tests/dummy/app/JsonApi/Videos/Adapter.php
+++ b/tests/dummy/app/JsonApi/Videos/Adapter.php
@@ -19,6 +19,7 @@ namespace DummyApp\JsonApi\Videos;
 
 use CloudCreativity\LaravelJsonApi\Document\ResourceObject;
 use CloudCreativity\LaravelJsonApi\Eloquent\AbstractAdapter;
+use CloudCreativity\LaravelJsonApi\Pagination\StandardStrategy;
 use DummyApp\Video;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
@@ -29,10 +30,12 @@ class Adapter extends AbstractAdapter
 
     /**
      * Adapter constructor.
+     *
+     * @param StandardStrategy $paging
      */
-    public function __construct()
+    public function __construct(StandardStrategy $paging)
     {
-        parent::__construct(new Video());
+        parent::__construct(new Video(), $paging);
     }
 
     /**

--- a/tests/dummy/app/JsonApi/Videos/Validators.php
+++ b/tests/dummy/app/JsonApi/Videos/Validators.php
@@ -29,6 +29,14 @@ class Validators extends AbstractValidators
     protected $allowedIncludePaths = ['uploaded-by'];
 
     /**
+     * @var array
+     */
+    protected $allowedSortParameters = [
+        'created-at',
+        'updated-at',
+    ];
+
+    /**
      * @inheritDoc
      */
     protected function rules($record = null): array

--- a/tests/lib/Integration/Pagination/StandardPagingTest.php
+++ b/tests/lib/Integration/Pagination/StandardPagingTest.php
@@ -17,8 +17,10 @@
 
 namespace CloudCreativity\LaravelJsonApi\Tests\Integration\Pagination;
 
+use Carbon\Carbon;
 use CloudCreativity\LaravelJsonApi\Pagination\StandardStrategy;
 use DummyApp\Post;
+use DummyApp\Video;
 
 class StandardPagingTest extends TestCase
 {
@@ -159,6 +161,40 @@ class StandardPagingTest extends TestCase
             'page' => ['number' => 1, 'size' => 3],
             'sort' => '-id',
         ])->assertFetchedManyInOrder($posts->take(3));
+    }
+
+    /**
+     * If we are sorting by a column that might not be unique, we expect
+     * the page to always be returned in a particular order i.e. by the
+     * key column.
+     *
+     * @see https://github.com/cloudcreativity/laravel-json-api/issues/313
+     */
+    public function testDeterministicOrder()
+    {
+        $first = factory(Video::class)->create([
+            'created_at' => Carbon::now()->subWeek(),
+        ]);
+
+        $f = factory(Video::class)->create([
+            'uuid' => 'f3b3bea3-dca0-4ef9-b06c-43583a7e6118',
+            'created_at' => Carbon::now()->subHour(),
+        ]);
+
+        $d = factory(Video::class)->create([
+            'uuid' => 'd215f35c-feb7-4cc5-9631-61742f00d0b2',
+            'created_at' => $f->created_at,
+        ]);
+
+        $c = factory(Video::class)->create([
+            'uuid' => 'cbe17134-d7e2-4509-ba2c-3b3b5e3b2cbe',
+            'created_at' => $f->created_at,
+        ]);
+
+        $this->withResourceType('videos')->doSearch([
+            'page' => ['number' => '1', 'size' => '3'],
+            'sort' => 'created-at'
+        ])->assertFetchedManyInOrder([$first, $c, $d]);
     }
 
     public function testCustomPageKeys()

--- a/tests/lib/Integration/Pagination/StandardPagingTest.php
+++ b/tests/lib/Integration/Pagination/StandardPagingTest.php
@@ -151,6 +151,16 @@ class StandardPagingTest extends TestCase
             ->assertFetchedPage($posts->last(), $links, $meta);
     }
 
+    public function testPageWithReverseKey()
+    {
+        $posts = factory(Post::class, 4)->create()->reverse()->values();
+
+        $this->doSearch([
+            'page' => ['number' => 1, 'size' => 3],
+            'sort' => '-id',
+        ])->assertFetchedManyInOrder($posts->take(3));
+    }
+
     public function testCustomPageKeys()
     {
         factory(Post::class, 4)->create();


### PR DESCRIPTION
Ensures records appear in the same order when using the standard strategy, by adding a deterministic sort order (i.e. sorting by the resource `id`).

Closes #313 