### PR TITLE
[fix] Async migration file was not ignored

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -82,10 +82,6 @@ class ServiceProvider extends BaseServiceProvider
         if ($this->app->runningInConsole()) {
             $this->bootMigrations();
 
-            $this->publishes([
-                __DIR__ . '/../database/migrations' => database_path('migrations'),
-            ], 'json-api-migrations');
-
             $this->commands([
                 Console\Commands\MakeAdapter::class,
                 Console\Commands\MakeApi::class,


### PR DESCRIPTION
During our process of upgrading the Package to the next most recent version, we encountered the problem that we could not continue without the migration. But we don't need this migration.

While investigating the problem i saw that the ServiceProvider is using the old way `$this->publishes` and the new way (`$this->loadMigrationsFrom` - implemented since L5.3) at the same time. The `$this->publishes` call dont have the Check.
Due to the fact that the package only supports >= Laravel 5.5, we do not need the second call.