### PR TITLE
[Feature] Add Eloquent adapter scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file. This projec
 
 ### Added
 - Added `domain` method to API fluent routing methods.
+- [#337](https://github.com/cloudcreativity/laravel-json-api/issues/337)
+Can now apply global scopes to JSON API resources via [adapter scopes.](./docs/basics/adapters.md#scopes)
 
 ## [1.1.0] - 2019-04-12
 

--- a/docs/basics/adapters.md
+++ b/docs/basics/adapters.md
@@ -495,6 +495,50 @@ modify this default behaviour and expose soft-deleting capabilities to the clien
 
 See the [Soft Deleting](../features/soft-deletes.md) for information on implementing this.
 
+### Scopes
+
+Eloquent adapters allow you to apply scopes to your API resources, using Laravel's
+[global scopes](https://laravel.com/docs/eloquent#global-scopes) feature.
+
+When a scope is applied to an Eloquent adapter, any routes that return that API resource in the response
+content will have the scope applied. An example use would be if you only want a user to access their own `posts`
+resources - you would add a scope to the `posts` adapter.
+
+Scopes can be added to an Eloquent adapter as either scope classes or as closure scopes. To use the former,
+write a class that implements Laravel's `Illuminate\Database\Eloquent\Scope` interface. The class can then
+be added to your adapter using constructor dependency injection and the `addScopes` method:
+
+```php
+namespace App\JsonApi\Posts;
+
+use CloudCreativity\LaravelJsonApi\Eloquent\AbstractAdapter;
+
+class Adapter extends AbstractAdapter
+{
+
+    public function __construct(\App\Scopes\UserScope $scope)
+    {
+      parent::__construct(new \App\Post());
+      $this->addScopes($scope);
+    }
+
+    // ...
+}
+```
+
+> Using a class scope allows you to reuse that scope across multiple adapters.
+
+If you prefer to use a closure for your scope, these can be added to an Eloquent adapter using the
+`addClosureScope` method. For example, in our `AppServiceProvider::register()` method:
+
+```php
+$this->app->afterResolving(\App\JsonApi\Posts\Adapter::class, function ($adapter) {
+  $adapter->addClosureScope(function ($query) {
+    $query->where('author_id', \Auth::id());
+  });
+});
+```
+
 ## Custom Adapters
 
 Custom adapters can be used for any domain record that is not an Eloquent model. Adapters will work with this

--- a/src/Eloquent/AbstractAdapter.php
+++ b/src/Eloquent/AbstractAdapter.php
@@ -28,6 +28,7 @@ use CloudCreativity\LaravelJsonApi\Exceptions\RuntimeException;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations;
+use Illuminate\Database\Eloquent\Scope;
 use Illuminate\Support\Collection;
 use Neomerx\JsonApi\Contracts\Encoder\Parameters\EncodingParametersInterface;
 use Neomerx\JsonApi\Encoder\Parameters\EncodingParameters;
@@ -87,6 +88,11 @@ abstract class AbstractAdapter extends AbstractResourceAdapter
     protected $defaultPagination = null;
 
     /**
+     * @var array
+     */
+    private $scopes;
+
+    /**
      * Apply the supplied filters to the builder instance.
      *
      * @param Builder $query
@@ -105,6 +111,7 @@ abstract class AbstractAdapter extends AbstractResourceAdapter
     {
         $this->model = $model;
         $this->paging = $paging;
+        $this->scopes = [];
     }
 
     /**
@@ -211,6 +218,37 @@ abstract class AbstractAdapter extends AbstractResourceAdapter
     }
 
     /**
+     * Add scopes.
+     *
+     * @param Scope ...$scopes
+     * @return $this
+     */
+    public function addScopes(Scope ...$scopes): self
+    {
+        foreach ($scopes as $scope) {
+            $this->scopes[get_class($scope)] = $scope;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Add a global scope using a closure.
+     *
+     * @param \Closure $scope
+     * @param string|null $identifier
+     * @return $this
+     */
+    public function addClosureScope(\Closure $scope, string $identifier = null): self
+    {
+        $identifier = $identifier ?: spl_object_hash($scope);
+
+        $this->scopes[$identifier] = $scope;
+
+        return $this;
+    }
+
+    /**
      * Get a new query builder.
      *
      * Child classes can overload this method if they want to modify the query instance that
@@ -220,7 +258,14 @@ abstract class AbstractAdapter extends AbstractResourceAdapter
      */
     protected function newQuery()
     {
-        return $this->model->newQuery();
+        $builder = $this->model->newQuery();
+
+        /** @var Scope $scope */
+        foreach ($this->scopes as $identifier => $scope) {
+            $builder->withGlobalScope($identifier, $scope);
+        }
+
+        return $builder;
     }
 
     /**

--- a/src/Eloquent/AbstractAdapter.php
+++ b/src/Eloquent/AbstractAdapter.php
@@ -137,8 +137,12 @@ abstract class AbstractAdapter extends AbstractResourceAdapter
      */
     public function queryToMany($relation, EncodingParametersInterface $parameters)
     {
+        $this->applyScopes(
+            $query = $relation->newQuery()
+        );
+
         return $this->queryAllOrOne(
-            $relation->newQuery(),
+            $query,
             $this->getQueryParameters($parameters)
         );
     }
@@ -155,8 +159,12 @@ abstract class AbstractAdapter extends AbstractResourceAdapter
      */
     public function queryToOne($relation, EncodingParametersInterface $parameters)
     {
+        $this->applyScopes(
+            $query = $relation->newQuery()
+        );
+
         return $this->queryOne(
-            $relation->newQuery(),
+            $query,
             $this->getQueryParameters($parameters)
         );
     }
@@ -249,6 +257,18 @@ abstract class AbstractAdapter extends AbstractResourceAdapter
     }
 
     /**
+     * @param Builder $query
+     * @return void
+     */
+    protected function applyScopes($query): void
+    {
+        /** @var Scope $scope */
+        foreach ($this->scopes as $identifier => $scope) {
+            $query->withGlobalScope($identifier, $scope);
+        }
+    }
+
+    /**
      * Get a new query builder.
      *
      * Child classes can overload this method if they want to modify the query instance that
@@ -258,12 +278,9 @@ abstract class AbstractAdapter extends AbstractResourceAdapter
      */
     protected function newQuery()
     {
-        $builder = $this->model->newQuery();
-
-        /** @var Scope $scope */
-        foreach ($this->scopes as $identifier => $scope) {
-            $builder->withGlobalScope($identifier, $scope);
-        }
+        $this->applyScopes(
+            $builder = $this->model->newQuery()
+        );
 
         return $builder;
     }

--- a/tests/lib/Integration/Eloquent/ScopesTest.php
+++ b/tests/lib/Integration/Eloquent/ScopesTest.php
@@ -18,6 +18,7 @@
 namespace CloudCreativity\LaravelJsonApi\Tests\Integration\Eloquent;
 
 use CloudCreativity\LaravelJsonApi\Tests\Integration\TestCase;
+use DummyApp\Country;
 use DummyApp\JsonApi\Posts\Adapter;
 use DummyApp\Post;
 use DummyApp\User;
@@ -74,5 +75,55 @@ class ScopesTest extends TestCase
         $post = factory(Post::class)->create();
 
         $this->getJsonApi(url('/api/v1/posts', $post))->assertStatus(404);
+    }
+
+    public function testReadToOne(): void
+    {
+        $this->markTestIncomplete('@todo');
+    }
+
+    public function testReadToOneRelationship(): void
+    {
+        $this->markTestIncomplete('@todo');
+    }
+
+    public function testReadToMany(): void
+    {
+        $country = factory(Country::class)->create();
+
+        $this->user->country()->associate($country);
+        $this->user->save();
+
+        $expected = factory(Post::class, 2)->create(['author_id' => $this->user->getKey()]);
+
+        factory(Post::class)->create([
+            'author_id' => factory(User::class)->create([
+                'country_id' => $country->getKey(),
+            ]),
+        ]);
+
+        $url = url('/api/v1/countries', [$country, 'posts']);
+
+        $this->getJsonApi($url)->assertFetchedMany($expected);
+    }
+
+    public function testReadToManyRelationship(): void
+    {
+        $country = factory(Country::class)->create();
+
+        $this->user->country()->associate($country);
+        $this->user->save();
+
+        $expected = factory(Post::class, 2)->create(['author_id' => $this->user->getKey()]);
+
+        factory(Post::class)->create([
+            'author_id' => factory(User::class)->create([
+                'country_id' => $country->getKey(),
+            ]),
+        ]);
+
+        $url = url('/api/v1/countries', [$country, 'relationships', 'posts']);
+
+        $this->getJsonApi($url)->assertFetchedToMany($expected);
     }
 }

--- a/tests/lib/Integration/Eloquent/ScopesTest.php
+++ b/tests/lib/Integration/Eloquent/ScopesTest.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Copyright 2019 Cloud Creativity Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace CloudCreativity\LaravelJsonApi\Tests\Integration\Eloquent;
+
+use CloudCreativity\LaravelJsonApi\Tests\Integration\TestCase;
+use DummyApp\JsonApi\Posts\Adapter;
+use DummyApp\Post;
+use DummyApp\User;
+
+class ScopesTest extends TestCase
+{
+
+    /**
+     * @var string
+     */
+    protected $resourceType = 'posts';
+
+    /**
+     * @var User
+     */
+    private $user;
+
+    /**
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = factory(User::class)->create();
+
+        $this->app->afterResolving(Adapter::class, function (Adapter $adapter) {
+            $adapter->addClosureScope(function ($query) {
+                $query->where('author_id', $this->user->getKey());
+            });
+        });
+    }
+
+    public function testListAll(): void
+    {
+        $expected = factory(Post::class, 2)->create(['author_id' => $this->user->getKey()]);
+        factory(Post::class, 3)->create();
+
+        $this->getJsonApi('/api/v1/posts')->assertFetchedMany($expected);
+    }
+
+    public function testRead(): void
+    {
+        $post = factory(Post::class)->create(['author_id' => $this->user->getKey()]);
+
+        $this->getJsonApi(url('/api/v1/posts', $post))->assertFetchedOne([
+            'type' => 'posts',
+            'id' => (string) $post->getRouteKey(),
+        ]);
+    }
+
+    public function testRead404(): void
+    {
+        $post = factory(Post::class)->create();
+
+        $this->getJsonApi(url('/api/v1/posts', $post))->assertStatus(404);
+    }
+}


### PR DESCRIPTION
Allows global scopes to be applied to an Eloquent adapter, either via constructor dependency injection or a closure.

Closes #337 