### PR TITLE
fix: assertInternalType is deprecated

### DIFF
--- a/src/Testing/TestResponse.php
+++ b/src/Testing/TestResponse.php
@@ -311,7 +311,14 @@ class TestResponse extends BaseTestResponse
         $id = $this->getId();
 
         Assert::assertNotEmpty($id, 'Create response does not include a valid id.');
-        Assert::assertInternalType('string', $id);
+
+        // Assert::assertIsString does not exist in PHPUnit < 7.5 but
+        // Assert::assertInternalType is deprecated in PHPUnit >= 8.0
+        if (method_exists(Assert::class, 'assertIsString')) {
+            Assert::assertIsString($id);
+        } else {
+            Assert::assertInternalType('string', $id);
+        }
 
         return $id;
     }


### PR DESCRIPTION
`Assert::assertInternalType` was deprecated in PHPUnit 8. Recommended migration path is to use the assertions per type added in PHPUnit 7.5. This is `Assert:assertIsString` for our use case.

I wasn't quite sure which PHPUnit versions are supported. `composer.json` of this package lists `^6.0|^7.0`. Therefore I added a fallback for PHPUnit < 7.5.