### PR TITLE
query() method of ValidatedRequest should have same interface as Illuminate\Http\Request

### DIFF
--- a/src/Http/Requests/ValidatedRequest.php
+++ b/src/Http/Requests/ValidatedRequest.php
@@ -148,11 +148,13 @@ abstract class ValidatedRequest implements ValidatesWhenResolved
     /**
      * Get parsed query parameters.
      *
-     * @return array
+     * @param  string|null  $key
+     * @param  string|array|null  $default
+     * @return string|array|null
      */
-    public function query()
+    public function query($key = null, $default = null)
     {
-        return $this->request->query();
+        return $this->request->query($key, $default);
     }
 
     /**


### PR DESCRIPTION
This adds support for retrieving a specific query param with a default value:

```php
$validatedRequest->query('name', 'Helen');
```

More information about that feature available in Laravel docs:
https://laravel.com/docs/5.8/requests#retrieving-input

It is available for all supported Laravel versions (5.5 and above).