### PR TITLE
Api::getContainer() return type fixed

### DIFF
--- a/src/Api/Api.php
+++ b/src/Api/Api.php
@@ -261,7 +261,7 @@ class Api
     }
 
     /**
-     * @return ContainerInterface|null
+     * @return ContainerInterface
      */
     public function getContainer()
     {


### PR DESCRIPTION
```php
if (!$this->container) {
    $this->container = $this->factory->createExtendedContainer($this->resolver);
}

return $this->container;
```

Factory::createExtendedContainer() always returns Container instance:
```php
/**
 * @inheritdoc
 */
public function createExtendedContainer(ResolverInterface $resolver)
{
    return new Container($this->container, $resolver);
}
```

This generates phpstan errors:
```php
-------------------------------------------------------------------------
 Line   Base/Schema.php
-------------------------------------------------------------------------
  48     Cannot call method getAdapterByResourceType() on
         CloudCreativity\LaravelJsonApi\Contracts\ContainerInterface|null.
-------------------------------------------------------------------------
```

On this code:
```php
/** @var Adapter $adapter */
$adapter = json_api()->getContainer()->getAdapterByResourceType(
    $this->resourceType
);
```