### PR TITLE
explicitly naming Laravel 5 is confusing

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Introduction
 
-Add [jsonapi.org](http://jsonapi.org) compliant APIs to your Laravel 5 application.
+Add [jsonapi.org](http://jsonapi.org) compliant APIs to your Laravel application.
 Based on the framework agnostic packages [neomerx/json-api](https://github.com/neomerx/json-api) and
 [cloudcreativity/json-api](https://github.com/cloudcreativity/json-api).
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -10,6 +10,9 @@ $ composer require --dev "cloudcreativity/json-api-testing:^1.2|^2.0"
 This package's service provider and facade will be automatically added using package discovery. You will
 then need to check your API route prefix and update your Exception handler as follows...
 
+Please find a compatibility matrix between Laravel and Laravel JSON API version in
+[project's readme on GitHub](https://github.com/cloudcreativity/laravel-json-api#laravel-versions).
+
 ## Route Prefixes
 
 The default Laravel installation has an `api` prefix for API routes. If you want to register your JSON API


### PR DESCRIPTION
Explicitly naming Laravel 5 was helpful for some time to distinguish from Laravel 4 packages. But as Laravel 6 and 7 were released this is confusing.

E.g. on StackOverflow someone assumed that this library is outdated as it's only for Laravel 5 and not for newer versions: https://stackoverflow.com/questions/60711249/how-to-use-jsonapi-spec-include-url-param-in-laravel-7-x-project?noredirect=1#comment107430380_60711249