### PR TITLE
Update ramsey/uuid from 3 to 4 to avoid conflicts with Laravel 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "illuminate/support": "^7.0",
         "neomerx/json-api": "^1.0.3",
         "nyholm/psr7": "^1.2",
-        "ramsey/uuid": "^3.0",
+        "ramsey/uuid": "^4.0",
         "symfony/psr-http-message-bridge": "^2.0"
     },
     "require-dev": {


### PR DESCRIPTION
# Poblem
When requiring the cloudcreativity/laravel-json-api (2.0.0-beta.1) from a fresh installation of Laravel 7 I'm getting the next error:
```bash
Problem 1
    - Installation request for cloudcreativity/laravel-json-api 2.0.0-beta.1 -> satisfiable by cloudcreativity/laravel-json-api[v2.0.0-beta.1].
    - Conclusion: remove ramsey/uuid 4.0.1
    - Conclusion: don't install ramsey/uuid 4.0.1
    - cloudcreativity/laravel-json-api v2.0.0-beta.1 requires ramsey/uuid ^3.0 -> satisfiable by ramsey/uuid[3.0.0, 3.0.0-alpha1, 3.0.0-alpha2, 3.0.0-alpha3, 3.0.0-beta1, 3.0.1, 3.1.0, 3.2.0, 3.3.0, 3.4.0, 3.4.1, 3.5.0, 3.5.1, 3.5.2, 3.6.0, 3.6.1, 3.7.0, 3.7.1, 3.7.2, 3.7.3, 3.8.0, 3.9.0, 3.9.1, 3.9.2, 3.9.3, 3.x-dev].
    - Can only install one of: ramsey/uuid[3.7.0, 4.0.1].
    - Can only install one of: ramsey/uuid[3.7.1, 4.0.1].
    - Can only install one of: ramsey/uuid[3.7.2, 4.0.1].
    - Can only install one of: ramsey/uuid[3.7.3, 4.0.1].
    - Can only install one of: ramsey/uuid[3.8.0, 4.0.1].
    - Can only install one of: ramsey/uuid[3.9.0, 4.0.1].
    - Can only install one of: ramsey/uuid[3.9.1, 4.0.1].
    - Can only install one of: ramsey/uuid[3.9.2, 4.0.1].
    - Can only install one of: ramsey/uuid[3.9.3, 4.0.1].
    - Can only install one of: ramsey/uuid[3.x-dev, 4.0.1].
    - Can only install one of: ramsey/uuid[3.0.0, 4.0.1].
    - Can only install one of: ramsey/uuid[3.0.0-alpha1, 4.0.1].
    - Can only install one of: ramsey/uuid[3.0.0-alpha2, 4.0.1].
    - Can only install one of: ramsey/uuid[3.0.0-alpha3, 4.0.1].
    - Can only install one of: ramsey/uuid[3.0.0-beta1, 4.0.1].
    - Can only install one of: ramsey/uuid[3.0.1, 4.0.1].
    - Can only install one of: ramsey/uuid[3.1.0, 4.0.1].
    - Can only install one of: ramsey/uuid[3.2.0, 4.0.1].
    - Can only install one of: ramsey/uuid[3.3.0, 4.0.1].
    - Can only install one of: ramsey/uuid[3.4.0, 4.0.1].
    - Can only install one of: ramsey/uuid[3.4.1, 4.0.1].
    - Can only install one of: ramsey/uuid[3.5.0, 4.0.1].
    - Can only install one of: ramsey/uuid[3.5.1, 4.0.1].
    - Can only install one of: ramsey/uuid[3.5.2, 4.0.1].
    - Can only install one of: ramsey/uuid[3.6.0, 4.0.1].
    - Can only install one of: ramsey/uuid[3.6.1, 4.0.1].
    - Installation request for ramsey/uuid (locked at 4.0.1) -> satisfiable by ramsey/uuid[4.0.1].


Installation failed, reverting ./composer.json to its original content.
```
# Solution
I upgraded the ramsey/uuid from 3 to 4, and now it's working on a fresh install of Laravel 7