### PR TITLE
Add support for model bindings in route params

### DIFF
--- a/src/Api/Url.php
+++ b/src/Api/Url.php
@@ -105,7 +105,7 @@ class Url
         foreach ($parameters as $key => $value) {
             $routeParamValue = $value;
 
-            if (method_exists($value, 'getRouteKey')) {
+            if ($value instanceof UrlRoutable) {
               $routeParamValue = $value->getRouteKey();
             }
 

--- a/src/Api/Url.php
+++ b/src/Api/Url.php
@@ -103,7 +103,13 @@ class Url
         $copy = clone $this;
 
         foreach ($parameters as $key => $value) {
-            $copy->namespace = \str_replace('{' . $key . '}', $value, $copy->namespace);
+            $routeParamValue = $value;
+
+            if (method_exists($value, 'getRouteKey')) {
+              $routeParamValue = $value->getRouteKey();
+            }
+
+            $copy->namespace = \str_replace('{' . $key . '}', $routeParamValue, $copy->namespace);
         }
 
         return $copy;

--- a/tests/lib/Integration/Routing/RouteParameterTest.php
+++ b/tests/lib/Integration/Routing/RouteParameterTest.php
@@ -20,6 +20,7 @@ namespace CloudCreativity\LaravelJsonApi\Tests\Integration\Routing;
 use CloudCreativity\LaravelJsonApi\Routing\RouteRegistrar;
 use CloudCreativity\LaravelJsonApi\Tests\Integration\TestCase;
 use DummyApp\Post;
+use DummyApp\User;
 use Illuminate\Support\Arr;
 
 /**
@@ -74,6 +75,18 @@ class RouteParameterTest extends TestCase
 
         $this->assertSame(
             url('/foo/bar/api/posts', $post),
+            Arr::get($data, 'data.links.self')
+        );
+    }
+
+    public function testModelBinding(): void
+    {
+        $post = factory(Post::class)->create();
+        $user = factory(User::class)->create();
+        $data = json_api(null, null, ['tenant' => $user])->encoder()->serializeData($post);
+
+        $this->assertSame(
+            url('/foo/2/api/posts', $post),
             Arr::get($data, 'data.links.self')
         );
     }


### PR DESCRIPTION
I noticed when I set my `url.namespace` to `api/v1/{tenant}`, if the `tenant` param was bound to a model the generated URLs would contain the JSON serialization, like so;

```json
"links": {
    "self": "http:\/\/api.example.test\/api\/v1\/{\"id\":1,\"name\":\"Tenant Name\",\"created_at\":\"2020-04-20T13:57:55.000000Z\",\"updated_at\":\"2020-04-20T13:57:55.000000Z\",\"slug\":\"test-slug\"}\/products\/1"
}
```

With this fix, bound models correctly use the route key;

```json
"links": {
    "self": "http:\/\/api.example.test\/api\/v1\/test-slug\/products\/1"
}
```