### PR TITLE
Fix MismatchingDocblockReturnType

### DIFF
--- a/stubs/independent/validators.stub
+++ b/stubs/independent/validators.stub
@@ -38,7 +38,7 @@ class DummyClass extends AbstractValidators
      *      the record being updated, or null if creating a resource.
      * @param array $data
      *      the data being validated
-     * @return mixed
+     * @return array
      */
     protected function rules($record, array $data): array
     {


### PR DESCRIPTION
Docblock has incorrect return type 'mixed', should be 'array<array-key, mixed>'