### PR TITLE
Update abstract adapter stub

### DIFF
--- a/stubs/abstract/adapter.stub
+++ b/stubs/abstract/adapter.stub
@@ -53,7 +53,7 @@ class DummyClass extends AbstractResourceAdapter
     /**
      * @inheritDoc
      */
-    public function exists($resourceId)
+    public function exists($resourceId): bool
     {
         // TODO: Implement exists() method.
     }

--- a/stubs/abstract/adapter.stub
+++ b/stubs/abstract/adapter.stub
@@ -53,7 +53,7 @@ class DummyClass extends AbstractResourceAdapter
     /**
      * @inheritDoc
      */
-    public function exists($resourceId): bool
+    public function exists(string $resourceId): bool
     {
         // TODO: Implement exists() method.
     }

--- a/stubs/abstract/adapter.stub
+++ b/stubs/abstract/adapter.stub
@@ -69,7 +69,7 @@ class DummyClass extends AbstractResourceAdapter
     /**
      * @inheritDoc
      */
-    public function findMany(array $resourceIds)
+    public function findMany(iterable $resourceIds): iterable
     {
         // TODO: Implement findMany() method.
     }


### PR DESCRIPTION
fixes these errors on a freshly generated abstract adapter:
```
Declaration of App\JsonApi\Adapters\SearchResultAdapter::exists($resourceId) must be compatible with CloudCreativity\LaravelJsonApi\Contracts\Adapter\ResourceAdapterInterface::exists(string $resourceId): bool
```
```
Declaration of App\JsonApi\Adapters\SearchResultAdapter::findMany(array $resourceIds) must be compatible with CloudCreativity\LaravelJsonApi\Contracts\Adapter\ResourceAdapterInterface::findMany(iterable $resourceIds): iterable
```