### PR TITLE
Add support for php 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: php
-dist: focal
+dist: xenial
 sudo: false
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,15 @@ sudo: false
 
 matrix:
   include:
-    - php: "7.3"
+    - php: 7.3
       env:
         - LARAVEL_VERSION=^8.0
         - PHPUNIT_VERSION=^9.0
-    - php: "7.4"
+    - php: 7.4
+      env:
+        - LARAVEL_VERSION=^8.0
+        - PHPUNIT_VERSION=^9.0
+    - php: 8.0snapshot
       env:
         - LARAVEL_VERSION=^8.0
         - PHPUNIT_VERSION=^9.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: php
-dist: trusty
+dist: focal
 sudo: false
 
 matrix:

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         }
     ],
     "require": {
-        "php": "^7.3",
+        "php": "^7.3|^8.0",
         "ext-json": "*",
         "illuminate/console": "^8.0",
         "illuminate/contracts": "^8.0",
@@ -41,7 +41,7 @@
         "cloudcreativity/json-api-testing": "^3.1",
         "guzzlehttp/guzzle": "^7.0",
         "laravel/legacy-factories": "^1.0.4",
-        "laravel/ui": "^2.0",
+        "laravel/ui": "^3.0",
         "mockery/mockery": "^1.1",
         "orchestra/testbench": "^6.0",
         "phpunit/phpunit": "^9.0"


### PR DESCRIPTION
This pull request adds support for php 8. The Travis dist had to change to xenial, as it is the only dist on Travis that currently supports php 7.3 - 8.0.