### PR TITLE
Feature: upgrade to Laravel 11 and drop PHP 8.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,8 +14,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.1, 8.2, 8.3]
-        laravel: [10]
+        php: [8.2, 8.3]
+        laravel: [11]
 
     steps:
       - name: Checkout Code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file. This project adheres to
 [Semantic Versioning](http://semver.org/) and [this changelog format](http://keepachangelog.com/).
 
-## Unreleased (Laravel 11)
+## Unreleased
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file. This project adheres to
 [Semantic Versioning](http://semver.org/) and [this changelog format](http://keepachangelog.com/).
 
+## Unreleased (Laravel 11)
+
+### Changed
+
+- **BREAKING** Package now requires Laravel 11.
+- Minimum PHP version is now `8.2`.
+
 ## Unreleased
 
 ## [6.1.0] - 2024-02-11

--- a/composer.json
+++ b/composer.json
@@ -61,8 +61,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-develop": "6.x-dev",
-            "dev-laravel11": "7.x-dev"
+            "dev-develop": "7.x-dev"
         },
         "laravel": {
             "providers": [
@@ -73,7 +72,7 @@
             }
         }
     },
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "prefer-stable": true,
     "config": {
         "sort-packages": true

--- a/composer.json
+++ b/composer.json
@@ -22,22 +22,22 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "ext-json": "*",
-        "laravel-json-api/neomerx-json-api": "^5.0.1",
-        "laravel/framework": "^10.0",
-        "nyholm/psr7": "^1.2",
+        "laravel-json-api/neomerx-json-api": "^5.0.2",
+        "laravel/framework": "^11.0",
+        "nyholm/psr7": "^1.8",
         "ramsey/uuid": "^4.0",
-        "symfony/psr-http-message-bridge": "^2.0"
+        "symfony/psr-http-message-bridge": "^7.0"
     },
     "require-dev": {
         "ext-sqlite3": "*",
-        "guzzlehttp/guzzle": "^7.0",
-        "laravel-json-api/testing": "^2.0",
-        "laravel/legacy-factories": "^1.0.4",
-        "laravel/ui": "^4.2",
-        "mockery/mockery": "^1.1",
-        "orchestra/testbench": "^8.0",
+        "guzzlehttp/guzzle": "^7.8",
+        "laravel-json-api/testing": "^3.0",
+        "laravel/legacy-factories": "^1.4.0",
+        "laravel/ui": "^4.4",
+        "mockery/mockery": "^1.6",
+        "orchestra/testbench": "^9.0",
         "phpunit/phpunit": "^10.5"
     },
     "suggest": {
@@ -61,7 +61,8 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-develop": "5.x-dev"
+            "dev-develop": "6.x-dev",
+            "dev-laravel11": "7.x-dev"
         },
         "laravel": {
             "providers": [
@@ -72,7 +73,7 @@
             }
         }
     },
-    "minimum-stability": "stable",
+    "minimum-stability": "dev",
     "prefer-stable": true,
     "config": {
         "sort-packages": true


### PR DESCRIPTION
Changes required to upgrade to Laravel 11. As Laravel 11 drops PHP 8.1, we'll do the same.